### PR TITLE
Fix sharp runtime error in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
         entry: "./server-entry.ts",
       },
     }),
-    nitro(),
+    nitro({
+      rollupConfig: {
+        external: ["sharp"],
+      },
+    }),
     tsconfigPaths(),
     tailwindcss(),
   ],


### PR DESCRIPTION
## Summary
- Externalize `sharp` from the Nitro/Rollup bundle to fix `Cannot read properties of undefined (reading 'bilinear')` runtime error in production
- Sharp has native bindings that break when inlined by the bundler; marking it as external lets it load from `node_modules` at runtime