### PR TITLE
Add external map links to place detail page

### DIFF
--- a/src/routes/places/-detail.ts
+++ b/src/routes/places/-detail.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { places, placeTags, tags, checkins, users, events } from "~/server/db/schema";
+import { env } from "~/server/env";
 
 export const GET = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -67,5 +68,6 @@ export const GET = async ({ request }: { request: Request }) => {
     recentCheckins,
     checkinCount: checkinCountRow?.count ?? 0,
     upcomingEvents,
+    mapLinkProviders: env.mapLinkProviders,
   });
 };

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -25,4 +25,7 @@ export const env = {
   s3AccessKeyId: process.env.AWS_ACCESS_KEY_ID || undefined,
   s3SecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || undefined,
   s3Region: process.env.AWS_REGION ?? "auto",
+
+  // Map link providers (comma-separated: kakao,naver,google)
+  mapLinkProviders: (process.env.MAP_LINK_PROVIDERS ?? "").split(",").map(s => s.trim()).filter(Boolean),
 };


### PR DESCRIPTION
## Summary
Add configurable external map service links (Google, Kakao, Naver) to the place detail page, displayed under the place title. The links are controlled by the `MAP_LINK_PROVIDERS` env var (comma-separated list of providers) and open the place location in the selected map service.

<img width="651" height="425" alt="스크린샷 2026-03-01 20 51 23" src="https://github.com/user-attachments/assets/6214cd61-836d-4a83-bfd6-716e886b8206" />
