### PR TITLE
Add event calendar page for groups

### DIFF
--- a/src/components/EventCalendar.tsx
+++ b/src/components/EventCalendar.tsx
@@ -1,0 +1,244 @@
+import { useState, useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Calendar, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { pickGradient } from "~/shared/gradients";
+import { cn } from "~/lib/utils";
+import {
+  getCalendarGrid,
+  isSameDay,
+  isCurrentMonth,
+  isToday,
+  eventOverlapsDay,
+  formatMonthYear,
+  dateKey,
+} from "~/lib/calendar";
+
+export type CalendarEvent = {
+  id: string;
+  title: string;
+  categoryId: string;
+  startsAt: string;
+  endsAt: string | null;
+  location: string | null;
+  organizerName?: string | null;
+  groupName?: string | null;
+};
+
+type EventCalendarProps = {
+  events: CalendarEvent[];
+};
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function EventCalendar({ events }: EventCalendarProps) {
+  const now = new Date();
+  const [currentYear, setCurrentYear] = useState(now.getFullYear());
+  const [currentMonth, setCurrentMonth] = useState(now.getMonth());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const days = useMemo(
+    () => getCalendarGrid(currentYear, currentMonth),
+    [currentYear, currentMonth],
+  );
+
+  const eventsMap = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const event of events) {
+      const start = new Date(event.startsAt);
+      const end = event.endsAt ? new Date(event.endsAt) : null;
+      for (const day of days) {
+        if (eventOverlapsDay(start, end, day)) {
+          const key = dateKey(day);
+          const list = map.get(key) ?? [];
+          list.push(event);
+          map.set(key, list);
+        }
+      }
+    }
+    return map;
+  }, [events, days]);
+
+  const selectedEvents = selectedDate
+    ? (eventsMap.get(dateKey(selectedDate)) ?? [])
+    : [];
+
+  function goToPrevMonth() {
+    setSelectedDate(null);
+    if (currentMonth === 0) {
+      setCurrentYear((y) => y - 1);
+      setCurrentMonth(11);
+    } else {
+      setCurrentMonth((m) => m - 1);
+    }
+  }
+
+  function goToNextMonth() {
+    setSelectedDate(null);
+    if (currentMonth === 11) {
+      setCurrentYear((y) => y + 1);
+      setCurrentMonth(0);
+    } else {
+      setCurrentMonth((m) => m + 1);
+    }
+  }
+
+  function handleDayClick(day: Date) {
+    if (!isCurrentMonth(day, currentYear, currentMonth)) {
+      setCurrentYear(day.getFullYear());
+      setCurrentMonth(day.getMonth());
+    }
+    setSelectedDate(day);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Navigation header */}
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="icon-xs" onClick={goToPrevMonth}>
+          <ChevronLeft className="size-4" />
+        </Button>
+        <span className="text-sm font-semibold">
+          {formatMonthYear(currentYear, currentMonth)}
+        </span>
+        <Button variant="ghost" size="icon-xs" onClick={goToNextMonth}>
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid" style={{ gridTemplateColumns: "repeat(7, 1fr)" }}>
+        {WEEKDAYS.map((d) => (
+          <div
+            key={d}
+            className="text-center text-xs font-medium text-muted-foreground py-1"
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid w-full" style={{ gridTemplateColumns: "repeat(7, 1fr)" }}>
+        {days.map((day, i) => {
+          const inMonth = isCurrentMonth(day, currentYear, currentMonth);
+          const today = isToday(day);
+          const key = dateKey(day);
+          const dayEvents = eventsMap.get(key) ?? [];
+          const isSelected =
+            selectedDate != null && isSameDay(day, selectedDate);
+
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => handleDayClick(day)}
+              className={cn(
+                "flex flex-col items-center py-2 rounded-md transition-colors overflow-visible min-h-24",
+                "text-xs sm:text-sm",
+                "hover:bg-accent/50",
+                !inMonth && "text-muted-foreground/40",
+                isSelected && "bg-accent ring-1 ring-primary/30",
+              )}
+            >
+              <span
+                className={cn(
+                  "size-6 flex items-center justify-center rounded-full text-xs sm:text-sm",
+                  today && "bg-primary text-primary-foreground font-bold ring-2 ring-primary/30",
+                )}
+              >
+                {day.getDate()}
+              </span>
+              {dayEvents.length > 0 && (
+                <div className="flex gap-0.5 mt-1">
+                  {dayEvents.slice(0, 3).map((evt) => {
+                    const [color] = pickGradient(evt.categoryId || evt.id);
+                    return (
+                      <span
+                        key={evt.id}
+                        className="size-2 rounded-full"
+                        style={{ backgroundColor: color }}
+                      />
+                    );
+                  })}
+                  {dayEvents.length > 3 && (
+                    <span className="text-[9px] text-muted-foreground leading-none">
+                      +{dayEvents.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Selected day detail */}
+      {selectedDate && (
+        <div className="border rounded-lg p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold">
+              {selectedDate.toLocaleDateString(undefined, {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+              })}
+            </h4>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => setSelectedDate(null)}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+
+          {selectedEvents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No events on this day.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {selectedEvents.map((evt) => {
+                const start = new Date(evt.startsAt);
+                const timeStr = start.toLocaleTimeString(undefined, {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+                const [color] = pickGradient(evt.categoryId || evt.id);
+
+                return (
+                  <Link
+                    key={evt.id}
+                    to="/events/$eventId"
+                    params={{ eventId: evt.id }}
+                    className="flex items-start gap-3 rounded-md p-2 hover:bg-accent/50 transition-colors"
+                  >
+                    <Calendar
+                      className="size-4 mt-0.5 shrink-0"
+                      style={{ color }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium leading-snug">
+                        {evt.title}
+                      </p>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+                        <span>{timeStr}</span>
+                        {evt.location && (
+                          <>
+                            <span>·</span>
+                            <span className="truncate">{evt.location}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/UpcomingEventList.tsx
+++ b/src/components/UpcomingEventList.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Clock, MapPin } from "lucide-react";
+import { pickGradient } from "~/shared/gradients";
+import type { CalendarEvent } from "~/components/EventCalendar";
+
+type UpcomingEventListProps = {
+  events: CalendarEvent[];
+};
+
+export function UpcomingEventList({ events }: UpcomingEventListProps) {
+  const groupedUpcoming = useMemo(() => {
+    const now = new Date();
+    const upcoming = events
+      .filter((e) => new Date(e.startsAt) >= now)
+      .sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime());
+
+    const groups: { dateLabel: string; events: CalendarEvent[] }[] = [];
+    let currentLabel = "";
+    for (const event of upcoming) {
+      const start = new Date(event.startsAt);
+      const label = start.toLocaleDateString(undefined, {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+      if (label !== currentLabel) {
+        groups.push({ dateLabel: label, events: [] });
+        currentLabel = label;
+      }
+      groups[groups.length - 1].events.push(event);
+    }
+    return groups;
+  }, [events]);
+
+  if (groupedUpcoming.length === 0) {
+    return (
+      <div className="rounded-lg border flex items-center justify-center py-16">
+        <p className="text-sm text-muted-foreground">No upcoming events</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groupedUpcoming.map((group) => (
+        <div key={group.dateLabel}>
+          <p className="text-md font-semibold text-foreground mb-2 px-1">{group.dateLabel}</p>
+          <div className="rounded-lg border divide-y ml-4">
+            {group.events.map((event) => {
+              const start = new Date(event.startsAt);
+              const timeStr = start.toLocaleTimeString(undefined, {
+                hour: "2-digit",
+                minute: "2-digit",
+              });
+              const [color] = pickGradient(event.categoryId || event.id);
+
+              return (
+                <Link
+                  key={event.id}
+                  to="/events/$eventId"
+                  params={{ eventId: event.id }}
+                  className="flex items-stretch hover:bg-accent/50 transition-colors first:rounded-t-lg last:rounded-b-lg"
+                >
+                  <div
+                    className="shrink-0 rounded-l-lg"
+                    style={{ backgroundColor: color, width: 3 }}
+                  />
+                  <div className="flex-1 min-w-0 px-3 py-2.5">
+                    <p className="text-sm font-medium leading-snug">{event.title}</p>
+                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <Clock style={{ width: 12, height: 12 }} className="shrink-0" />
+                        {timeStr}
+                      </span>
+                      {event.location && (
+                        <span className="flex items-center gap-1 truncate">
+                          <MapPin style={{ width: 12, height: 12 }} className="shrink-0" />
+                          <span className="truncate">{event.location}</span>
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure calendar date utilities using native Date API.
+ */
+
+/** Return a 42-element array of Dates (6 weeks × 7 days) for a month grid starting on Sunday. */
+export function getCalendarGrid(year: number, month: number): Date[] {
+  const firstDay = new Date(year, month, 1);
+  const startOffset = firstDay.getDay(); // 0 = Sunday
+  const gridStart = new Date(year, month, 1 - startOffset);
+
+  const days: Date[] = [];
+  for (let i = 0; i < 42; i++) {
+    days.push(new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i));
+  }
+  return days;
+}
+
+/** Check whether two Dates fall on the same calendar day. */
+export function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate();
+}
+
+/** Check whether a Date falls within a given year/month. */
+export function isCurrentMonth(date: Date, year: number, month: number): boolean {
+  return date.getFullYear() === year && date.getMonth() === month;
+}
+
+/** Check whether a Date is today. */
+export function isToday(date: Date): boolean {
+  return isSameDay(date, new Date());
+}
+
+/** Strip time from a Date, returning midnight of that day. */
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
+ * Check whether an event overlaps with a particular calendar day.
+ * - Point events (endsAt is null): overlaps if startsAt is on that day.
+ * - Ranged events: overlaps if the day falls between startsAt and endsAt (inclusive, date-only).
+ */
+export function eventOverlapsDay(
+  startsAt: Date,
+  endsAt: Date | null,
+  day: Date,
+): boolean {
+  const dayStart = startOfDay(day).getTime();
+  const eventStart = startOfDay(startsAt).getTime();
+
+  if (endsAt == null) {
+    return dayStart === eventStart;
+  }
+
+  const eventEnd = startOfDay(endsAt).getTime();
+  return dayStart >= eventStart && dayStart <= eventEnd;
+}
+
+/** Format a month/year as e.g. "March 2026". */
+export function formatMonthYear(year: number, month: number): string {
+  const d = new Date(year, month, 1);
+  return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+/** Format a date key as "YYYY-MM-DD" for use as a Map key. */
+export function dateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}

--- a/src/routes/groups/$identifier/events.tsx
+++ b/src/routes/groups/$identifier/events.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { actors } from "~/server/db/schema";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import { EventCalendar, type CalendarEvent } from "~/components/EventCalendar";
+import { UpcomingEventList } from "~/components/UpcomingEventList";
+import { Calendar, ChevronLeft, List } from "lucide-react";
+
+const getGroupMeta = createServerFn({ method: "GET" })
+  .inputValidator(zodValidator(z.object({ handle: z.string() })))
+  .handler(async ({ data }) => {
+    const [group] = await db
+      .select({ name: actors.name, handle: actors.handle, domain: actors.domain })
+      .from(actors)
+      .where(and(eq(actors.handle, data.handle), eq(actors.type, "Group"), eq(actors.isLocal, true)))
+      .limit(1);
+    return group ?? null;
+  });
+
+export const Route = createFileRoute("/groups/$identifier/events")({
+  component: GroupEventsPage,
+  loader: async ({ params }) => {
+    const handle = params.identifier.startsWith("@")
+      ? params.identifier.slice(1)
+      : params.identifier;
+    return getGroupMeta({ data: { handle } });
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return {};
+    const name = loaderData.name ?? `@${loaderData.handle}`;
+    return {
+      meta: [
+        { title: `Events — ${name} — Moim` },
+        { name: "description", content: `Event calendar for ${name}` },
+        { property: "og:title", content: `Events — ${name}` },
+        { property: "og:type", content: "website" },
+      ],
+    };
+  },
+});
+
+function GroupEventsPage() {
+  const { identifier } = Route.useParams();
+  const handle = identifier.replace(/^@/, "");
+
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<"calendar" | "upcoming">("calendar");
+
+  useEffect(() => {
+    fetch(`/api/groups/by-handle/${encodeURIComponent(handle)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        setEvents(d.events ?? []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [handle]);
+
+  const groupName = `@${handle}`;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon-xs" asChild>
+            <Link to="/groups/$identifier" params={{ identifier }}>
+              <ChevronLeft className="size-4" />
+            </Link>
+          </Button>
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">Events</h2>
+            <p className="text-sm text-muted-foreground">{groupName}</p>
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant={view === "calendar" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("calendar")}
+          >
+            <Calendar className="size-4" />
+            Calendar
+          </Button>
+          <Button
+            variant={view === "upcoming" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("upcoming")}
+          >
+            <List className="size-4" />
+            Upcoming
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : view === "calendar" ? (
+        <Card className="rounded-lg">
+          <CardContent className="pt-6">
+            <EventCalendar events={events} />
+          </CardContent>
+        </Card>
+      ) : (
+        <UpcomingEventList events={events} />
+      )}
+    </div>
+  );
+}

--- a/src/routes/groups/$identifier/index.tsx
+++ b/src/routes/groups/$identifier/index.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Badge } from "~/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 import { RemoteFollowDialog } from "~/components/RemoteFollowDialog";
+import { Calendar } from "lucide-react";
 
 const getGroupMeta = createServerFn({ method: "GET" })
   .inputValidator(zodValidator(z.object({ handle: z.string() })))
@@ -174,6 +175,12 @@ function ProfilePage() {
                   </Link>
                 </Button>
               )}
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/groups/$identifier/events" params={{ identifier }}>
+                  <Calendar className="size-4" />
+                  Events
+                </Link>
+              </Button>
               <RemoteFollowDialog actorHandle={handle} />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add a dedicated events page (`/groups/:identifier/events`) with a calendar view and upcoming events list for groups
- Introduce reusable `EventCalendar` and `UpcomingEventList` components, along with pure calendar date utilities in `src/lib/calendar.ts`
- Add an "Events" button to the group profile page for easy navigation

closes: #47

## Screenshots

<img width="768" height="688" alt="스크린샷 2026-03-04 15 15 55" src="https://github.com/user-attachments/assets/12f66d73-6391-4763-bbdf-39a4368eb342" />
<img width="765" height="676" alt="스크린샷 2026-03-04 15 15 58" src="https://github.com/user-attachments/assets/cc213dd0-f97d-4666-baeb-8a9a12a99c01" />


## Test plan
- [x] Navigate to a group profile and verify the "Events" button appears
- [x] Click through to the events page and confirm both Calendar and Upcoming views render
- [x] Test month navigation (prev/next) and day selection in the calendar view
- [x] Verify events with date ranges span across multiple calendar days