### PR TITLE
Add event calendar page for places

### DIFF
--- a/src/routes/places/$placeId/events.tsx
+++ b/src/routes/places/$placeId/events.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { places } from "~/server/db/schema";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import { EventCalendar, type CalendarEvent } from "~/components/EventCalendar";
+import { UpcomingEventList } from "~/components/UpcomingEventList";
+import { Calendar, ChevronLeft, List } from "lucide-react";
+
+const getPlaceMeta = createServerFn({ method: "GET" })
+  .inputValidator(zodValidator(z.object({ placeId: z.string() })))
+  .handler(async ({ data }) => {
+    const [row] = await db
+      .select({ name: places.name })
+      .from(places)
+      .where(eq(places.id, data.placeId))
+      .limit(1);
+    return row ?? null;
+  });
+
+export const Route = createFileRoute("/places/$placeId/events")({
+  component: PlaceEventsPage,
+  loader: async ({ params }) => {
+    return getPlaceMeta({ data: { placeId: params.placeId } });
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return {};
+    return {
+      meta: [
+        { title: `Events — ${loaderData.name} — Moim` },
+        { name: "description", content: `Event calendar for ${loaderData.name}` },
+        { property: "og:title", content: `Events — ${loaderData.name}` },
+        { property: "og:type", content: "website" },
+      ],
+    };
+  },
+});
+
+function PlaceEventsPage() {
+  const { placeId } = Route.useParams();
+  const loaderData = Route.useLoaderData();
+
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<"calendar" | "upcoming">("calendar");
+
+  useEffect(() => {
+    fetch(`/api/places/${placeId}/events`)
+      .then((r) => r.json())
+      .then((d) => {
+        setEvents(d.events ?? []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [placeId]);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon-xs" asChild>
+            <Link to="/places/$placeId" params={{ placeId }}>
+              <ChevronLeft className="size-4" />
+            </Link>
+          </Button>
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">Events</h2>
+            <p className="text-sm text-muted-foreground">
+              {loaderData?.name ?? "Place"}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant={view === "calendar" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("calendar")}
+          >
+            <Calendar className="size-4" />
+            Calendar
+          </Button>
+          <Button
+            variant={view === "upcoming" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setView("upcoming")}
+          >
+            <List className="size-4" />
+            Upcoming
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : view === "calendar" ? (
+        <Card className="rounded-lg">
+          <CardContent className="pt-6">
+            <EventCalendar events={events} />
+          </CardContent>
+        </Card>
+      ) : (
+        <UpcomingEventList events={events} />
+      )}
+    </div>
+  );
+}

--- a/src/routes/places/$placeId/index.tsx
+++ b/src/routes/places/$placeId/index.tsx
@@ -28,6 +28,7 @@ import { Separator } from "~/components/ui/separator";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 import { usePostHog } from "posthog-js/react";
 import { LeafletMap } from "~/components/LeafletMap";
+import { Calendar } from "lucide-react";
 import type { PlaceCategorySummary } from "~/lib/place";
 
 const getPlaceMeta = createServerFn({ method: "GET" })
@@ -107,6 +108,7 @@ type PlaceDetail = {
     title: string;
     startsAt: string;
   }>;
+  managedByGroup: boolean;
   mapLinkProviders: string[];
 };
 
@@ -178,7 +180,7 @@ function PlaceDetailPage() {
     );
   }
 
-  const { place, tags, recentCheckins, checkinCount, upcomingEvents, mapLinkProviders } = data;
+  const { place, tags, recentCheckins, checkinCount, upcomingEvents, managedByGroup, mapLinkProviders } = data;
   const hasCoords = place.latitude && place.longitude;
   const categoryPath = data.categoryPath ?? [];
   const mapLinks = hasCoords
@@ -219,9 +221,19 @@ function PlaceDetailPage() {
             </div>
           )}
         </div>
-        {user && (
-          <Button onClick={() => setCheckinOpen(true)}>Check In</Button>
-        )}
+        <div className="flex gap-2">
+          {managedByGroup && (
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/places/$placeId/events" params={{ placeId: place.id }}>
+                <Calendar className="size-4" />
+                Events
+              </Link>
+            </Button>
+          )}
+          {user && (
+            <Button onClick={() => setCheckinOpen(true)}>Check In</Button>
+          )}
+        </div>
       </div>
 
       {/* Tags */}

--- a/src/routes/places/-detail.ts
+++ b/src/routes/places/-detail.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "~/server/db/client";
-import { checkins, events, placeCategories, places, placeTags, tags, users } from "~/server/db/schema";
+import { checkins, events, groupPlaces, placeCategories, places, placeTags, tags, users } from "~/server/db/schema";
 import { env } from "~/server/env";
 import { getCategoryPath, getPlaceCategories } from "~/server/places/categories";
 
@@ -41,7 +41,7 @@ export const GET = async ({ request }: { request: Request }) => {
   }
 
   // Run independent queries in parallel
-  const [placeTags_, recentCheckins, [checkinCountRow], upcomingEvents] =
+  const [placeTags_, recentCheckins, [checkinCountRow], upcomingEvents, [groupPlaceRow]] =
     await Promise.all([
       db
         .select({
@@ -79,6 +79,10 @@ export const GET = async ({ request }: { request: Request }) => {
         .where(and(eq(events.placeId, placeId), gte(events.startsAt, new Date())))
         .orderBy(events.startsAt)
         .limit(5),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(groupPlaces)
+        .where(eq(groupPlaces.placeId, placeId)),
     ]);
 
   const categoryPath = place.categoryId
@@ -113,6 +117,7 @@ export const GET = async ({ request }: { request: Request }) => {
     recentCheckins,
     checkinCount: checkinCountRow?.count ?? 0,
     upcomingEvents,
+    managedByGroup: (groupPlaceRow?.count ?? 0) > 0,
     mapLinkProviders: env.mapLinkProviders,
   });
 };

--- a/src/routes/places/-events.ts
+++ b/src/routes/places/-events.ts
@@ -1,0 +1,36 @@
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { actors, events, users } from "~/server/db/schema";
+
+export const GET = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const placeId = url.searchParams.get("placeId");
+
+  if (!placeId) {
+    return Response.json({ error: "placeId is required" }, { status: 400 });
+  }
+
+  const placeEvents = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      categoryId: events.categoryId,
+      startsAt: events.startsAt,
+      endsAt: events.endsAt,
+      location: events.location,
+      organizerName: users.displayName,
+      groupName: actors.name,
+    })
+    .from(events)
+    .innerJoin(users, eq(events.organizerId, users.id))
+    .innerJoin(actors, eq(events.groupActorId, actors.id))
+    .where(
+      and(
+        eq(events.placeId, placeId),
+        isNotNull(events.groupActorId),
+      ),
+    )
+    .orderBy(events.startsAt);
+
+  return Response.json({ events: placeEvents });
+};

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -36,6 +36,7 @@ import { GET as placeCheckins } from "./routes/places/-checkins";
 import { GET as nearbyPlaces } from "./routes/places/-nearby";
 import { POST as findOrCreatePlace } from "./routes/places/-find-or-create";
 import { GET as listPlaceCategories } from "./routes/places/-categories";
+import { GET as placeEvents } from "./routes/places/-events";
 import { GET as serveMap } from "./routes/maps/-serve";
 import { GET as serveAvatar } from "./routes/avatars/-serve";
 import { GET as serveBanner } from "./routes/banners/-serve";
@@ -341,6 +342,14 @@ apiRouter.get("/places/:placeId", defineEventHandler(async (event) => {
   const placeId = event.context.params?.placeId;
   return placeDetail({
     request: forwardGet(request, `/api/places/${placeId}`, { id: placeId }),
+  });
+}));
+
+apiRouter.get("/places/:placeId/events", defineEventHandler(async (event) => {
+  const request = toWebRequest(event);
+  const placeId = event.context.params?.placeId;
+  return placeEvents({
+    request: forwardGet(request, `/api/places/${placeId}/events`, { placeId }),
   });
 }));
 


### PR DESCRIPTION
## Summary
- Add a calendar view at `/places/:placeId/events` showing group-organized events at a venue, reusing the `EventCalendar` and `UpcomingEventList` components
- Add an "Events" button to the place detail page header, visible only when the place is managed by a group
- Add a dedicated API endpoint (`GET /api/places/:placeId/events`) that returns group-organized events for a place

Resolves #49


## Screenshot 

<img width="823" height="506" alt="스크린샷 2026-03-04 15 28 57" src="https://github.com/user-attachments/assets/9caba179-5a32-4d45-9dad-45f4ee71041b" />
