### PR TITLE
Add RSS feed endpoint for groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.38.0",
+    "feed": "^5.2.0",
     "frimousse": "^0.3.0",
     "h3": "^1.12.0",
     "leaflet": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@opentelemetry/api@1.9.0)(@types/react@19.2.14)(pg@8.18.0)(react@19.1.0)
+      feed:
+        specifier: ^5.2.0
+        version: 5.2.0
       frimousse:
         specifier: ^0.3.0
         version: 0.3.0(react@19.1.0)(typescript@5.9.3)
@@ -3357,6 +3360,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.2.0:
+    resolution: {integrity: sha512-hgH6CCb+7+0c8PBlakI2KubG6R+Rb1MhpNcdvqUXZTBwBHf32piwY255diAkAmkGZ6AWlywOU88AkOgP9q8Rdw==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
@@ -4181,6 +4188,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.5.0:
+    resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -4581,6 +4592,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
@@ -8110,6 +8125,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  feed@5.2.0:
+    dependencies:
+      xml-js: 1.6.11
+
   fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
@@ -8985,6 +9004,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.5.0: {}
+
   scheduler@0.26.0: {}
 
   semver@6.3.1: {}
@@ -9269,6 +9290,10 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.5.0
 
   xmlbuilder2@4.0.3:
     dependencies:

--- a/src/routes/groups/$identifier/index.tsx
+++ b/src/routes/groups/$identifier/index.tsx
@@ -50,6 +50,14 @@ export const Route = createFileRoute("/groups/$identifier/")({
         { property: "og:type", content: "profile" },
         { property: "fediverse:creator", content: fullHandle },
       ],
+      links: [
+        {
+          rel: "alternate",
+          type: "application/rss+xml",
+          title: `${loaderData.name ?? loaderData.handle} — RSS`,
+          href: `/groups/@${loaderData.handle}/feed.xml`,
+        },
+      ],
     };
   },
 });

--- a/src/routes/groups/-feed.ts
+++ b/src/routes/groups/-feed.ts
@@ -1,0 +1,139 @@
+import { eq, and, isNull, desc } from "drizzle-orm";
+import { Feed } from "feed";
+import { db } from "~/server/db/client";
+import { actors, events, posts } from "~/server/db/schema";
+import { env } from "~/server/env";
+
+const FEED_LIMIT = 50;
+
+export const GET = async ({
+  request,
+}: { request: Request }): Promise<Response> => {
+  const url = new URL(request.url);
+  const handle = url.searchParams.get("handle");
+
+  if (!handle) {
+    return new Response("handle is required", { status: 400 });
+  }
+
+  const [group] = await db
+    .select({
+      id: actors.id,
+      handle: actors.handle,
+      name: actors.name,
+      summary: actors.summary,
+      language: actors.language,
+    })
+    .from(actors)
+    .where(and(eq(actors.handle, handle), eq(actors.type, "Group")))
+    .limit(1);
+
+  if (!group) {
+    return new Response("Group not found", { status: 404 });
+  }
+
+  const baseUrl = env.baseUrl;
+  const groupUrl = `${baseUrl}/groups/@${group.handle}`;
+  const feedUrl = `${groupUrl}/feed.xml`;
+
+  const groupEvents = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      description: events.description,
+      startsAt: events.startsAt,
+      location: events.location,
+      createdAt: events.createdAt,
+    })
+    .from(events)
+    .where(eq(events.groupActorId, group.id))
+    .orderBy(desc(events.createdAt))
+    .limit(FEED_LIMIT);
+
+  const groupPosts = await db
+    .select({
+      id: posts.id,
+      content: posts.content,
+      published: posts.published,
+    })
+    .from(posts)
+    .where(and(eq(posts.actorId, group.id), isNull(posts.eventId)))
+    .orderBy(desc(posts.published))
+    .limit(FEED_LIMIT);
+
+  type FeedEntry = { date: Date; addToFeed: (feed: Feed) => void };
+  const items: FeedEntry[] = [];
+
+  for (const e of groupEvents) {
+    const date = new Date(e.createdAt);
+    const descriptionParts = [
+      e.description,
+      e.startsAt
+        ? `Date: ${new Date(e.startsAt).toISOString()}`
+        : null,
+      e.location ? `Location: ${e.location}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    items.push({
+      date,
+      addToFeed: (feed) => {
+        feed.addItem({
+          title: e.title,
+          id: `${baseUrl}/events/${e.id}`,
+          link: `${baseUrl}/events/${e.id}`,
+          description: descriptionParts || undefined,
+          date,
+          category: [{ name: "Event" }],
+        });
+      },
+    });
+  }
+
+  for (const p of groupPosts) {
+    const date = new Date(p.published);
+    const plainText = p.content.replace(/<[^>]*>/g, "").slice(0, 80) || "Note";
+
+    items.push({
+      date,
+      addToFeed: (feed) => {
+        feed.addItem({
+          title: plainText,
+          id: `${baseUrl}/notes/${p.id}`,
+          link: `${baseUrl}/notes/${p.id}`,
+          content: p.content,
+          date,
+          category: [{ name: "Note" }],
+        });
+      },
+    });
+  }
+
+  items.sort((a, b) => b.date.getTime() - a.date.getTime());
+  const topItems = items.slice(0, FEED_LIMIT);
+
+  const displayName = group.name ?? `@${group.handle}`;
+
+  const feed = new Feed({
+    title: displayName,
+    description: group.summary ?? `Activity from ${displayName}`,
+    id: groupUrl,
+    link: groupUrl,
+    language: group.language ?? undefined,
+    feedLinks: { rss2: feedUrl },
+    updated: topItems.length > 0 ? topItems[0].date : new Date(),
+    copyright: "",
+  });
+
+  for (const item of topItems) {
+    item.addToFeed(feed);
+  }
+
+  return new Response(feed.rss2(), {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=900",
+    },
+  });
+};

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -54,6 +54,7 @@ import { GET as userDetail } from "./routes/admin/users/-detail";
 import { GET as getCarouselSlides } from "./routes/-carousel";
 import { POST as trackBannerClick } from "./routes/-banner-click";
 import { POST as webfingerLookup } from "./routes/api/-webfinger";
+import { GET as groupFeed } from "./routes/groups/-feed";
 
 const startFetch = createStartHandler(defaultStreamHandler);
 
@@ -509,8 +510,18 @@ app.use("/banners", defineEventHandler(async (event) => {
 
 app.use(
   fromWebHandler(async (request) => {
-    // Content negotiation: serve AP object directly for /notes/{uuid} and /places/{uuid}
     const url = new URL(request.url);
+
+    // RSS feed for groups
+    const feedMatch = url.pathname.match(/^\/groups\/@([^/]+)\/feed\.xml$/);
+    if (feedMatch) {
+      const handle = decodeURIComponent(feedMatch[1]);
+      return groupFeed({
+        request: forwardGet(request, "/groups/feed", { handle }),
+      });
+    }
+
+    // Content negotiation: serve AP object directly for /notes/{uuid} and /places/{uuid}
     const noteMatch = url.pathname.match(/^\/notes\/([0-9a-f-]{36})$/);
     if (noteMatch) {
       const ctx = federation.createContext(request, undefined);


### PR DESCRIPTION
## Summary
- Adds `GET /groups/@{handle}/feed.xml` endpoint that returns an RSS 2.0 feed combining a group's events and posts, sorted by date descending (limit 50 items)
- Adds RSS autodiscovery `<link>` tag in the group profile page `<head>` so RSS readers can auto-detect the feed
- Uses the `feed` npm package for XML generation with 15-minute cache headers

Resolves #62