### PR TITLE
Add admin-panel-style layout to event dashboard

### DIFF
--- a/src/routes/events/$eventId/dashboard.tsx
+++ b/src/routes/events/$eventId/dashboard.tsx
@@ -1,15 +1,22 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { CATEGORIES } from "~/shared/categories";
 import { Button } from "~/components/ui/button";
 import { Badge } from "~/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
+import { Card, CardContent } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "~/components/ui/card";
+  LayoutDashboard,
+  Users,
+  Activity,
+  ArrowLeft,
+  ExternalLink,
+  Pencil,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 
 export const Route = createFileRoute("/events/$eventId/dashboard")({
   component: EventDashboard,
@@ -36,14 +43,7 @@ type DashboardData = {
     declined: number;
     total: number;
   };
-  attendees: {
-    userId: string;
-    handle: string | null;
-    displayName: string;
-    avatarUrl: string | null;
-    status: string;
-    createdAt: string;
-  }[];
+  attendees: Attendee[];
   engagementCounts: {
     reactions: number;
     announces: number;
@@ -59,7 +59,40 @@ type DashboardData = {
     actorHandle: string;
     actorName: string | null;
   }[];
+  participantEngagement: ParticipantEngagement[];
 };
+
+type Attendee = {
+  userId: string;
+  handle: string | null;
+  displayName: string;
+  avatarUrl: string | null;
+  status: string;
+  createdAt: string;
+};
+
+type ParticipantEngagement = {
+  actorId: string;
+  actorHandle: string;
+  actorName: string | null;
+  reactionCount: number;
+  replyCount: number;
+  announceCount: number;
+  totalEngagement: number;
+};
+
+type ActivityItem = {
+  id: string;
+  type: string;
+  emoji: string | null;
+  content: string | null;
+  createdAt: string;
+  actorId: string;
+  actorHandle: string;
+  actorName: string | null;
+};
+
+type Tab = "overview" | "attendees" | "activity";
 
 function EventDashboard() {
   const { eventId } = Route.useParams();
@@ -68,7 +101,7 @@ function EventDashboard() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [activityFilter, setActivityFilter] = useState<"all" | "reactions" | "reposts" | "reply">("all");
+  const [activeTab, setActiveTab] = useState<Tab>("overview");
 
   useEffect(() => {
     fetch(`/api/events/${eventId}/dashboard`)
@@ -90,20 +123,11 @@ function EventDashboard() {
       });
   }, [eventId, navigate]);
 
-  if (loading) return <p className="text-muted-foreground">Loading...</p>;
+  if (loading) return <p className="text-muted-foreground p-6">Loading...</p>;
   if (error || !data)
-    return <p className="text-destructive">{error || "Not found"}</p>;
+    return <p className="text-destructive p-6">{error || "Not found"}</p>;
 
-  const { event, rsvpCounts, attendees, engagementCounts, recentActivity } =
-    data;
-
-  const filteredActivity = recentActivity.filter((a) => {
-    if (activityFilter === "all") return true;
-    if (activityFilter === "reactions") return a.type === "like" || a.type === "emoji_react";
-    if (activityFilter === "reposts") return a.type === "announce";
-    if (activityFilter === "reply") return a.type === "reply" || a.type === "quote";
-    return true;
-  });
+  const { event } = data;
 
   const statusVariant = {
     upcoming: "default" as const,
@@ -111,23 +135,39 @@ function EventDashboard() {
     ended: "secondary" as const,
   };
 
+  const NAV_ITEMS: { tab: Tab; icon: typeof LayoutDashboard; label: string }[] = [
+    { tab: "overview", icon: LayoutDashboard, label: "Overview" },
+    { tab: "attendees", icon: Users, label: "Attendees" },
+    { tab: "activity", icon: Activity, label: "Activity" },
+  ];
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <h2 className="text-2xl font-semibold tracking-tight truncate">
-              {event.title}
-            </h2>
-            <Badge variant={statusVariant[event.status]}>{event.status}</Badge>
+    <div className="-mx-6 -my-8 flex min-h-[calc(100vh-3.5rem)]">
+      {/* Sidebar */}
+      <aside className="flex w-56 shrink-0 flex-col border-r bg-muted/30">
+        <div className="border-b p-4">
+          <Link
+            to="/events/$eventId"
+            params={{ eventId }}
+            className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            Back to Event
+          </Link>
+          <h1 className="mt-3 text-base font-semibold truncate" title={event.title}>
+            {event.title}
+          </h1>
+          <div className="mt-1.5 flex items-center gap-1.5">
+            <Badge variant={statusVariant[event.status]} className="text-xs">
+              {event.status}
+            </Badge>
             {event.categoryId && categoryMap.has(event.categoryId) && (
-              <Badge variant="outline">
+              <Badge variant="outline" className="text-xs">
                 {categoryMap.get(event.categoryId)}
               </Badge>
             )}
           </div>
-          <p className="text-sm text-muted-foreground">
+          <p className="mt-1.5 text-xs text-muted-foreground">
             {new Date(event.startsAt).toLocaleDateString(undefined, {
               weekday: "short",
               month: "short",
@@ -135,167 +175,255 @@ function EventDashboard() {
               hour: "2-digit",
               minute: "2-digit",
             })}
-            {event.endsAt &&
-              ` — ${new Date(event.endsAt).toLocaleDateString(undefined, {
-                weekday: "short",
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-              })}`}
           </p>
         </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <Button variant="outline" size="sm" asChild>
-            <Link to="/events/$eventId" params={{ eventId }}>
-              Public Page
-            </Link>
-          </Button>
-          <Button variant="outline" size="sm" asChild>
-            <Link to="/events/$eventId/edit" params={{ eventId }}>
-              Edit Event
-            </Link>
-          </Button>
+
+        <nav className="flex-1 space-y-0.5 p-3">
+          {NAV_ITEMS.map((item) => {
+            const isActive = activeTab === item.tab;
+            return (
+              <button
+                key={item.tab}
+                onClick={() => setActiveTab(item.tab)}
+                className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+                  isActive
+                    ? "bg-accent font-medium text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                }`}
+              >
+                <item.icon className="size-4" />
+                {item.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="border-t p-3 space-y-1">
+          <Link
+            to="/events/$eventId"
+            params={{ eventId }}
+            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          >
+            <ExternalLink className="size-4" />
+            Public Page
+          </Link>
+          <Link
+            to="/events/$eventId/edit"
+            params={{ eventId }}
+            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          >
+            <Pencil className="size-4" />
+            Edit Event
+          </Link>
         </div>
+      </aside>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        {activeTab === "overview" && <OverviewTab data={data} />}
+        {activeTab === "attendees" && <AttendeesTab data={data} />}
+        {activeTab === "activity" && <ActivityTab eventId={eventId} />}
+      </div>
+    </div>
+  );
+}
+
+// ── Overview Tab ────────────────────────────────────────────────────────────
+
+function OverviewTab({ data }: { data: DashboardData }) {
+  const { rsvpCounts, engagementCounts } = data;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Overview</h2>
+        <p className="mt-1 text-muted-foreground">
+          Event insights and engagement summary.
+        </p>
       </div>
 
-      {/* Insights */}
-      <Card className="rounded-lg">
-        <CardHeader>
-          <CardTitle className="text-base">Insights</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="rounded-lg border p-4 space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Attending
-              </p>
-              <p className="text-3xl font-bold">{rsvpCounts.accepted}</p>
-            </div>
-            <div className="rounded-lg border p-4 space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Total RSVPs
-              </p>
-              <p className="text-3xl font-bold">{rsvpCounts.total}</p>
-            </div>
-            <div className="rounded-lg border p-4 space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Reactions
-              </p>
-              <p className="text-3xl font-bold">{engagementCounts.reactions}</p>
-            </div>
-            <div className="rounded-lg border p-4 space-y-2">
-              <p className="text-sm font-medium text-muted-foreground">
-                Boosts
-              </p>
-              <p className="text-3xl font-bold">{engagementCounts.announces}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Attending" value={rsvpCounts.accepted} />
+        <StatCard label="Total RSVPs" value={rsvpCounts.total} />
+        <StatCard label="Reactions" value={engagementCounts.reactions} />
+        <StatCard label="Boosts" value={engagementCounts.announces} />
+        <StatCard label="Replies" value={engagementCounts.replies} />
+        <StatCard label="Quotes" value={engagementCounts.quotes} />
+      </div>
+    </div>
+  );
+}
 
-      {/* Attendees */}
-      <Card className="rounded-lg">
-        <CardHeader>
-          <CardTitle className="text-base">
-            Attendees (
-            {attendees.filter((a) => a.status === "accepted").length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {attendees.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-8 text-center">
-              No RSVPs yet.
-            </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left text-muted-foreground">
-                    <th className="pb-3 pr-4 font-medium">Name</th>
-                    <th className="pb-3 pr-4 font-medium">Status</th>
-                    <th className="pb-3 font-medium">RSVP Date</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {attendees.map((a) => (
-                    <tr
-                      key={a.userId}
-                      className="border-b last:border-b-0"
-                    >
-                      <td className="py-3 pr-4">
-                        <div className="flex items-center gap-2">
-                          <Avatar className="size-8">
-                            {a.avatarUrl && (
-                              <AvatarImage src={a.avatarUrl} />
-                            )}
-                            <AvatarFallback className="text-xs">
-                              {a.displayName.charAt(0).toUpperCase()}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div>
-                            <span className="font-medium">
-                              {a.displayName}
-                            </span>
-                            {a.handle && (
-                              <span className="text-muted-foreground ml-1.5">
-                                @{a.handle}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </td>
-                      <td className="py-3 pr-4">
-                        <Badge
-                          variant={
-                            a.status === "accepted" ? "default" : "secondary"
-                          }
-                        >
-                          {a.status === "accepted"
-                            ? "Attending"
-                            : "Not attending"}
-                        </Badge>
-                      </td>
-                      <td className="py-3 text-muted-foreground">
-                        {new Date(a.createdAt).toLocaleDateString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+// ── Attendees Tab ───────────────────────────────────────────────────────────
 
-      {/* Recent Activity */}
-      <Card className="rounded-lg">
-        <CardHeader>
-          <div className="flex items-center justify-between gap-4">
-            <CardTitle className="text-base">Recent Activity</CardTitle>
-            <div className="flex gap-1">
-              {(["all", "reply", "reactions", "reposts"] as const).map((f) => (
-                <Button
-                  key={f}
-                  variant={activityFilter === f ? "default" : "outline"}
-                  size="sm"
-                  className="text-xs h-7 px-2.5"
-                  onClick={() => setActivityFilter(f)}
-                >
-                  {f === "all" ? "All" : f === "reply" ? "Replies" : f === "reactions" ? "Reactions" : "Reposts"}
-                </Button>
+function AttendeesTab({ data }: { data: DashboardData }) {
+  const { attendees } = data;
+  const [search, setSearch] = useState("");
+
+  const filteredAttendees = attendees.filter((a) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      a.displayName.toLowerCase().includes(q) ||
+      (a.handle?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Attendees</h2>
+        <p className="mt-1 text-muted-foreground">
+          RSVP list ({attendees.length} total).
+        </p>
+      </div>
+
+      <div className="relative max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+        <Input
+          placeholder="Search attendees..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {filteredAttendees.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          {search ? "No attendees match your search." : "No RSVPs yet."}
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-3 text-left font-medium">Attendee</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">RSVP Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredAttendees.map((a) => (
+                <tr key={a.userId} className="border-b last:border-0 hover:bg-muted/30">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <Avatar className="size-8">
+                        {a.avatarUrl && <AvatarImage src={a.avatarUrl} />}
+                        <AvatarFallback className="text-xs">
+                          {a.displayName.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <span className="font-medium">{a.displayName}</span>
+                        {a.handle && (
+                          <span className="text-muted-foreground ml-1.5 text-xs">
+                            @{a.handle}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Badge variant={a.status === "accepted" ? "default" : "secondary"}>
+                      {a.status === "accepted" ? "Attending" : "Not attending"}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs">
+                    {new Date(a.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
               ))}
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {filteredActivity.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-8 text-center">
-              No fediverse engagement yet.
-            </p>
-          ) : (
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Activity Tab ────────────────────────────────────────────────────────────
+
+const ACTIVITY_PAGE_SIZE = 20;
+
+function ActivityTab({ eventId }: { eventId: string }) {
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+
+  const fetchActivity = useCallback(() => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    params.set("limit", String(ACTIVITY_PAGE_SIZE));
+    params.set("offset", String(offset));
+    if (typeFilter) params.set("type", typeFilter);
+
+    fetch(`/api/events/${eventId}/dashboard/activity?${params}`)
+      .then((r) => r.json())
+      .then((data) => {
+        setItems(data.items ?? []);
+        setTotal(data.total ?? 0);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [eventId, offset, typeFilter]);
+
+  useEffect(() => {
+    fetchActivity();
+  }, [fetchActivity]);
+
+  const typeFilters: { key: string | null; label: string }[] = [
+    { key: null, label: "All" },
+    { key: "replies", label: "Replies" },
+    { key: "reactions", label: "Reactions" },
+    { key: "reposts", label: "Reposts" },
+  ];
+
+  const totalPages = Math.ceil(total / ACTIVITY_PAGE_SIZE);
+  const currentPage = Math.floor(offset / ACTIVITY_PAGE_SIZE) + 1;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Activity</h2>
+        <p className="mt-1 text-muted-foreground">
+          Engagement timeline.
+        </p>
+      </div>
+
+      {/* Type Filters */}
+      <div className="flex gap-1">
+        {typeFilters.map((f) => (
+          <Button
+            key={f.key ?? "all"}
+            variant={typeFilter === f.key ? "default" : "outline"}
+            size="sm"
+            className="text-xs h-7 px-2.5"
+            onClick={() => {
+              setTypeFilter(f.key);
+              setOffset(0);
+            }}
+          >
+            {f.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Activity List */}
+      {loading ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          Loading activity...
+        </p>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          No engagement activity found.
+        </p>
+      ) : (
+        <Card>
+          <CardContent className="pt-6">
             <ul className="space-y-2">
-              {filteredActivity.map((a) => (
+              {items.map((a) => (
                 <li
                   key={a.id}
                   className="flex items-center gap-3 py-2 border-b last:border-b-0"
@@ -330,7 +458,8 @@ function EventDashboard() {
                       your post
                     </span>
                     {a.content && (a.type === "reply" || a.type === "quote") && (
-                      <p className="text-xs text-muted-foreground mt-1 line-clamp-2"
+                      <p
+                        className="text-xs text-muted-foreground mt-1 line-clamp-2"
                         dangerouslySetInnerHTML={{ __html: a.content }}
                       />
                     )}
@@ -346,9 +475,49 @@ function EventDashboard() {
                 </li>
               ))}
             </ul>
-          )}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {currentPage} of {totalPages} ({total} items)
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - ACTIVITY_PAGE_SIZE))}
+            >
+              <ChevronLeft className="size-4 mr-1" />
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset + ACTIVITY_PAGE_SIZE >= total}
+              onClick={() => setOffset(offset + ACTIVITY_PAGE_SIZE)}
+            >
+              Next
+              <ChevronRight className="size-4 ml-1" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Shared Components ───────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <p className="text-3xl font-bold">{value}</p>
     </div>
   );
 }

--- a/src/routes/events/-dashboard-activity.ts
+++ b/src/routes/events/-dashboard-activity.ts
@@ -1,0 +1,105 @@
+import { eq, and, sql, type SQL } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import {
+  events,
+  actors,
+  groupMembers,
+  activityLogs,
+} from "~/server/db/schema";
+import { getSessionUser } from "~/server/auth";
+
+export const GET = async ({ request }: { request: Request }) => {
+  const user = await getSessionUser(request);
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const eventId = url.searchParams.get("eventId");
+  if (!eventId) {
+    return Response.json({ error: "eventId is required" }, { status: 400 });
+  }
+
+  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "20", 10), 100);
+  const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
+  const actorId = url.searchParams.get("actorId");
+  const type = url.searchParams.get("type"); // like, emoji_react, announce, reply, quote
+
+  // Get event + access check
+  const [event] = await db
+    .select({ id: events.id, groupActorId: events.groupActorId })
+    .from(events)
+    .where(eq(events.id, eventId))
+    .limit(1);
+
+  if (!event) {
+    return Response.json({ error: "Event not found" }, { status: 404 });
+  }
+  if (!event.groupActorId) {
+    return Response.json({ error: "Dashboard is only available for group events" }, { status: 400 });
+  }
+
+  const [membership] = await db
+    .select({ role: groupMembers.role })
+    .from(groupMembers)
+    .innerJoin(actors, eq(groupMembers.memberActorId, actors.id))
+    .where(
+      and(
+        eq(groupMembers.groupActorId, event.groupActorId),
+        eq(actors.userId, user.id),
+        eq(actors.type, "Person"),
+      ),
+    )
+    .limit(1);
+
+  if (!membership) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Build where conditions
+  const conditions: SQL[] = [eq(activityLogs.eventId, eventId)];
+  if (actorId) {
+    conditions.push(eq(activityLogs.actorId, actorId));
+  }
+  if (type) {
+    // Support compound filters
+    if (type === "reactions") {
+      conditions.push(sql`${activityLogs.type} in ('like', 'emoji_react')`);
+    } else if (type === "reposts") {
+      conditions.push(eq(activityLogs.type, "announce"));
+    } else if (type === "replies") {
+      conditions.push(sql`${activityLogs.type} in ('reply', 'quote')`);
+    } else {
+      conditions.push(eq(activityLogs.type, type));
+    }
+  }
+
+  const whereClause = and(...conditions)!;
+
+  // Count total
+  const [{ total }] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(activityLogs)
+    .where(whereClause);
+
+  // Fetch page
+  const items = await db
+    .select({
+      id: activityLogs.id,
+      type: activityLogs.type,
+      emoji: activityLogs.emoji,
+      content: activityLogs.content,
+      createdAt: activityLogs.createdAt,
+      actorId: activityLogs.actorId,
+      actorHandle: actors.handle,
+      actorName: actors.name,
+    })
+    .from(activityLogs)
+    .innerJoin(actors, eq(activityLogs.actorId, actors.id))
+    .where(whereClause)
+    .orderBy(sql`${activityLogs.createdAt} DESC`)
+    .limit(limit)
+    .offset(offset);
+
+  return Response.json({ items, total });
+};

--- a/src/routes/events/-dashboard.ts
+++ b/src/routes/events/-dashboard.ts
@@ -131,6 +131,23 @@ export const GET = async ({ request }: { request: Request }) => {
     .orderBy(sql`${activityLogs.createdAt} DESC`)
     .limit(20);
 
+  // Per-participant engagement breakdown
+  const participantEngagement = await db
+    .select({
+      actorId: activityLogs.actorId,
+      actorHandle: actors.handle,
+      actorName: actors.name,
+      reactionCount: sql<number>`count(*) filter (where ${activityLogs.type} in ('like', 'emoji_react'))::int`,
+      replyCount: sql<number>`count(*) filter (where ${activityLogs.type} in ('reply', 'quote'))::int`,
+      announceCount: sql<number>`count(*) filter (where ${activityLogs.type} = 'announce')::int`,
+      totalEngagement: sql<number>`count(*)::int`,
+    })
+    .from(activityLogs)
+    .innerJoin(actors, eq(activityLogs.actorId, actors.id))
+    .where(eq(activityLogs.eventId, eventId))
+    .groupBy(activityLogs.actorId, actors.handle, actors.name)
+    .orderBy(sql`count(*) DESC`);
+
   // Compute event status
   const now = new Date();
   const status =
@@ -146,5 +163,6 @@ export const GET = async ({ request }: { request: Request }) => {
     attendees,
     engagementCounts,
     recentActivity,
+    participantEngagement,
   });
 };

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -56,6 +56,7 @@ import { POST as trackBannerClick } from "./routes/-banner-click";
 import { POST as webfingerLookup } from "./routes/api/-webfinger";
 import { GET as groupFeed } from "./routes/groups/-feed";
 import { GET as eventDashboard } from "./routes/events/-dashboard";
+import { GET as eventDashboardActivity } from "./routes/events/-dashboard-activity";
 
 const startFetch = createStartHandler(defaultStreamHandler);
 
@@ -320,6 +321,14 @@ apiRouter.get("/events/:eventId/dashboard", defineEventHandler(async (event) => 
   const eventId = event.context.params?.eventId;
   return eventDashboard({
     request: forwardGet(request, `/api/events/${eventId}/dashboard`, { eventId }),
+  });
+}));
+
+apiRouter.get("/events/:eventId/dashboard/activity", defineEventHandler(async (event) => {
+  const request = toWebRequest(event);
+  const eventId = event.context.params?.eventId;
+  return eventDashboardActivity({
+    request: forwardGet(request, `/api/events/${eventId}/dashboard/activity`, { eventId }),
   });
 }));
 


### PR DESCRIPTION
## Summary
- Rewrite the event dashboard (`/events/$eventId/dashboard`) with an admin-panel-style sidebar layout and three navigable tabs: Overview (RSVP + engagement stat cards), Attendees (searchable RSVP list), and Activity (paginated engagement timeline with type filters)
- Add a dedicated paginated activity API endpoint (`GET /api/events/:eventId/dashboard/activity`) supporting type-based filtering and pagination
- Add per-participant engagement breakdown query to the existing dashboard API for future use

## Screenshot 

<img width="1084" height="815" alt="스크린샷 2026-03-04 18 23 32" src="https://github.com/user-attachments/assets/d75b137a-666d-4ee2-8cff-2d45997b2e0a" />


## Test plan
- [x] Navigate to `/events/{id}/dashboard` for a group event and verify the sidebar renders with Overview/Attendees/Activity tabs
- [x] Verify Overview tab shows RSVP and engagement stat cards
- [x] Verify Attendees tab shows RSVP list with search filtering
- [x] Verify Activity tab shows paginated timeline with type filters (All/Replies/Reactions/Reposts)
- [x] Verify pagination controls appear when activity exceeds 20 items
- [x] Verify non-group-member access redirects to the public event page