### PR TITLE
Fix duplicate events from multi-actor join

### DIFF
--- a/src/routes/-carousel.ts
+++ b/src/routes/-carousel.ts
@@ -81,7 +81,7 @@ export const GET = async () => {
       .leftJoin(
         organizerActors,
         and(
-          eq(organizerActors.userId, users.id),
+          eq(organizerActors.handle, userFediverseAccounts.fediverseHandle),
           eq(organizerActors.isLocal, false),
         ),
       )
@@ -117,7 +117,7 @@ export const GET = async () => {
         .leftJoin(
           organizerActors,
           and(
-            eq(organizerActors.userId, users.id),
+            eq(organizerActors.handle, userFediverseAccounts.fediverseHandle),
             eq(organizerActors.isLocal, false),
           ),
         )

--- a/src/routes/events/-detail.ts
+++ b/src/routes/events/-detail.ts
@@ -43,7 +43,7 @@ export const GET = async ({ request }: { request: Request }) => {
       eq(userFediverseAccounts.isPrimary, true),
     ))
     .leftJoin(organizerActors, and(
-      eq(organizerActors.userId, users.id),
+      eq(organizerActors.handle, userFediverseAccounts.fediverseHandle),
       eq(organizerActors.isLocal, false),
     ))
     .leftJoin(places, eq(events.placeId, places.id))

--- a/src/routes/events/-list.ts
+++ b/src/routes/events/-list.ts
@@ -32,7 +32,7 @@ export const GET = async ({ request }: { request: Request }) => {
       eq(userFediverseAccounts.isPrimary, true),
     ))
     .leftJoin(organizerActors, and(
-      eq(organizerActors.userId, users.id),
+      eq(organizerActors.handle, userFediverseAccounts.fediverseHandle),
       eq(organizerActors.isLocal, false),
     ))
     .where(past ? lt(events.startsAt, now) : gte(events.startsAt, now))


### PR DESCRIPTION
## Summary
- Fixes event list, detail, and carousel showing duplicate events when a user has multiple remote actors (from linked fediverse accounts)
- Joins organizer actor via the primary account's `fediverseHandle` instead of `userId`, ensuring exactly one match per event