### PR TITLE
Fix map zoom reset on marker updates

### DIFF
--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -43,6 +43,7 @@ export function LeafletMap({
   onMapClickRef.current = onMapClick;
   const onMarkerClickRef = useRef(onMarkerClick);
   onMarkerClickRef.current = onMarkerClick;
+  const prevViewRef = useRef<{ center?: [number, number]; zoom?: number }>({});
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
@@ -200,7 +201,11 @@ export function LeafletMap({
         const currentZoom = mapRef.current.getZoom();
         mapRef.current.setView([markers[0].lat, markers[0].lng], Math.max(currentZoom, zoom));
       } else if (!fitToMarkers) {
-        mapRef.current.setView(center, zoom);
+        const prev = prevViewRef.current;
+        if (!prev.center || prev.center[0] !== center[0] || prev.center[1] !== center[1] || prev.zoom !== zoom) {
+          mapRef.current.setView(center, zoom);
+          prevViewRef.current = { center, zoom };
+        }
       } else if (markers.length === 0 && !gpsRequestedRef.current) {
         // No markers — try to center on user's GPS location and place a marker
         gpsRequestedRef.current = true;


### PR DESCRIPTION
## Summary
When `fitToMarkers={false}`, the LeafletMap effect was calling `setView(center, zoom)` on every marker change (e.g. highlight color toggling when selecting a nearby place card), resetting the user's zoom level. Added a `prevViewRef` to track the last applied center/zoom and only call `setView` when they actually change.