### PR TITLE
Add zoom-based radius and circle overlay to map

### DIFF
--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -13,13 +13,20 @@ export type MapMarker = {
   highlighted?: boolean;
 };
 
+type CircleOverlay = {
+  center: [number, number];
+  radiusKm: number;
+};
+
 type LeafletMapProps = {
   center?: [number, number];
   zoom?: number;
   markers?: MapMarker[];
+  circle?: CircleOverlay;
   fitToMarkers?: boolean;
   onMapClick?: (lat: number, lng: number) => void;
   onMarkerClick?: (marker: MapMarker) => void;
+  onZoomEnd?: (zoom: number) => void;
   height?: string;
   className?: string;
 };
@@ -31,18 +38,23 @@ export function LeafletMap({
   fitToMarkers = true,
   onMapClick,
   onMarkerClick,
+  onZoomEnd,
+  circle,
   height = "300px",
   className,
 }: LeafletMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
+  const circleRef = useRef<any>(null);
   const gpsMarkerRef = useRef<any>(null);
   const gpsRequestedRef = useRef(false);
   const onMapClickRef = useRef(onMapClick);
   onMapClickRef.current = onMapClick;
   const onMarkerClickRef = useRef(onMarkerClick);
   onMarkerClickRef.current = onMarkerClick;
+  const onZoomEndRef = useRef(onZoomEnd);
+  onZoomEndRef.current = onZoomEnd;
   const prevViewRef = useRef<{ center?: [number, number]; zoom?: number }>({});
   const [isClient, setIsClient] = useState(false);
 
@@ -88,6 +100,10 @@ export function LeafletMap({
 
         mapRef.current.on("click", (e: any) => {
           onMapClickRef.current?.(e.latlng.lat, e.latlng.lng);
+        });
+
+        mapRef.current.on("zoomend", () => {
+          onZoomEndRef.current?.(mapRef.current.getZoom());
         });
       }
 
@@ -193,6 +209,22 @@ export function LeafletMap({
         markersRef.current.push(m);
       }
 
+      // Update circle overlay
+      if (circleRef.current) {
+        circleRef.current.remove();
+        circleRef.current = null;
+      }
+      if (circle) {
+        circleRef.current = L.circle(circle.center, {
+          radius: circle.radiusKm * 1000,
+          color: "#3b82f6",
+          fillColor: "#3b82f6",
+          fillOpacity: 0.06,
+          weight: 1.5,
+          dashArray: "6 4",
+        }).addTo(mapRef.current);
+      }
+
       // Fit bounds if multiple markers
       if (fitToMarkers && markers.length > 1) {
         const bounds = L.latLngBounds(markers.map((m) => [m.lat, m.lng]));
@@ -236,7 +268,7 @@ export function LeafletMap({
     return () => {
       cancelled = true;
     };
-  }, [isClient, markers, center, zoom, fitToMarkers]);
+  }, [isClient, markers, center, zoom, fitToMarkers, circle]);
 
   // Invalidate map size when container resizes (e.g. body style changes from modals)
   useEffect(() => {

--- a/src/routes/places/index.tsx
+++ b/src/routes/places/index.tsx
@@ -58,6 +58,15 @@ function formatRelativeTime(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString();
 }
 
+function zoomToRadius(zoom: number): number {
+  if (zoom >= 18) return 0.2;
+  if (zoom >= 16) return 0.5;
+  if (zoom >= 14) return 1;
+  if (zoom >= 12) return 2;
+  if (zoom >= 10) return 5;
+  return 10;
+}
+
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -85,6 +94,7 @@ function CheckinsPage() {
   const [user, setUser] = useState<{ handle: string } | null>(null);
   const [placeCategories, setPlaceCategories] = useState<PlaceCategoryOption[]>([]);
   const [mapCenter, setMapCenter] = useState<[number, number] | null>(null);
+  const [mapZoom, setMapZoom] = useState(13);
   const [gpsLoading, setGpsLoading] = useState(true);
 
   // Nearby places
@@ -175,10 +185,10 @@ function CheckinsPage() {
     );
   }, []);
 
-  // Fetch nearby places when map center changes
-  const fetchNearby = useCallback((lat: number, lng: number) => {
+  // Fetch nearby places when map center or zoom changes
+  const fetchNearby = useCallback((lat: number, lng: number, radius: number) => {
     setNearbyLoading(true);
-    fetch(`/api/places/nearby?lat=${lat}&lng=${lng}&radius=2`)
+    fetch(`/api/places/nearby?lat=${lat}&lng=${lng}&radius=${radius}`)
       .then((r) => r.json())
       .then((data) => setNearbyPlaces(data.places ?? []))
       .catch(() => setNearbyPlaces([]))
@@ -186,8 +196,8 @@ function CheckinsPage() {
   }, []);
 
   useEffect(() => {
-    if (mapCenter) fetchNearby(mapCenter[0], mapCenter[1]);
-  }, [mapCenter, fetchNearby]);
+    if (mapCenter) fetchNearby(mapCenter[0], mapCenter[1], zoomToRadius(mapZoom));
+  }, [mapCenter, mapZoom, fetchNearby]);
 
   // Select a nearby place (sets pin, fetches recent check-ins, does NOT open dialog)
   const selectPlace = (place: NearbyPlace) => {
@@ -218,7 +228,7 @@ function CheckinsPage() {
     setSelectedPlace(null);
     setCheckinError("");
     setPinnedLocation({ lat: lat.toFixed(6), lng: lng.toFixed(6) });
-    fetchNearby(lat, lng);
+    fetchNearby(lat, lng, zoomToRadius(mapZoom));
   };
 
   // Map marker click
@@ -290,7 +300,7 @@ function CheckinsPage() {
       setPinnedLocation(null);
 
       // Re-fetch nearby to update counts
-      if (mapCenter) fetchNearby(mapCenter[0], mapCenter[1]);
+      if (mapCenter) fetchNearby(mapCenter[0], mapCenter[1], zoomToRadius(mapZoom));
     } catch {
       setCheckinError("Failed to check in");
     } finally {
@@ -430,9 +440,11 @@ function CheckinsPage() {
       <LeafletMap
         center={mapCenter ?? undefined}
         markers={[...nearbyMarkers, ...pickedMarker]}
+        circle={pinnedLocation ? { center: [parseFloat(pinnedLocation.lat), parseFloat(pinnedLocation.lng)], radiusKm: zoomToRadius(mapZoom) } : undefined}
         fitToMarkers={false}
         onMapClick={handleMapClick}
         onMarkerClick={handleMarkerClick}
+        onZoomEnd={setMapZoom}
         height={isMobile ? "350px" : "500px"}
       />
 


### PR DESCRIPTION
## Summary
Dynamically adjust the nearby places search radius based on the current map zoom level, replacing the fixed 2km radius. A dashed blue circle overlay visualizes the active search area on the map, and the `onZoomEnd` callback keeps the radius and overlay in sync as the user zooms in or out.

## Screenshot 

|Before|After|
|-|-|
|<img width="320" height="274" alt="스크린샷 2026-03-05 16 48 25" src="https://github.com/user-attachments/assets/5a024334-c35c-4867-9489-b184391136d2" />|<img width="589" height="372" alt="스크린샷 2026-03-05 16 48 36" src="https://github.com/user-attachments/assets/76618237-b549-41c0-b933-08d8840c0380" />|

