### PR TITLE
Fix RSVP bar hidden by bottom nav on mobile

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, createContext, useContext } from "react";
+import { useState, useEffect, createContext, useContext, type ReactNode } from "react";
 import {
   createRootRoute,
   Outlet,
@@ -32,6 +32,18 @@ const AuthContext = createContext<{
 
 export function useAuth() {
   return useContext(AuthContext);
+}
+
+const BottomBarSlotContext = createContext<{
+  setBottomBar: (node: ReactNode) => void;
+}>({ setBottomBar: () => {} });
+
+export function useBottomBarSlot(node: ReactNode) {
+  const { setBottomBar } = useContext(BottomBarSlotContext);
+  useEffect(() => {
+    setBottomBar(node);
+    return () => setBottomBar(null);
+  }, [node, setBottomBar]);
 }
 
 const getPublicConfig = createServerFn({ method: "GET" }).handler(async () => ({
@@ -87,6 +99,7 @@ function RootLayout() {
   const config = Route.useLoaderData();
   const [user, setUser] = useState<SessionUser>(null);
   const [loaded, setLoaded] = useState(false);
+  const [bottomBar, setBottomBar] = useState<ReactNode>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -113,6 +126,7 @@ function RootLayout() {
       <body className="min-h-screen bg-background font-sans antialiased">
         <PostHogWrapper config={config}>
         <AuthContext.Provider value={{ user, setUser, loaded }}>
+        <BottomBarSlotContext.Provider value={{ setBottomBar }}>
           <div className="relative flex min-h-screen flex-col">
             {/* Header */}
             <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -198,11 +212,14 @@ function RootLayout() {
               </div>
             </footer>
 
-            {/* Bottom tab bar (mobile only) */}
-            <nav
-              className="fixed bottom-0 inset-x-0 z-50 border-t bg-background md:hidden"
-              style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
-            >
+            {/* Bottom bar slot + tab bar (mobile only) */}
+            <div className="fixed bottom-0 inset-x-0 z-50 md:hidden" style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}>
+              {bottomBar && (
+                <div className="border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+                  {bottomBar}
+                </div>
+              )}
+              <nav className="border-t bg-background">
               <div className="flex items-center justify-around h-14">
                 <Link
                   to="/events"
@@ -226,9 +243,11 @@ function RootLayout() {
                   <span className="text-[10px] font-medium">{user ? "Profile" : "Sign in"}</span>
                 </Link>
               </div>
-            </nav>
+              </nav>
+            </div>
           </div>
           <Scripts />
+        </BottomBarSlotContext.Provider>
         </AuthContext.Provider>
         </PostHogWrapper>
 

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useBottomBarSlot } from "~/routes/__root";
 import { createServerFn } from "@tanstack/react-start";
 import { zodValidator } from "@tanstack/zod-adapter";
-import { useEffect, useState } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { z } from "zod";
 import { LeafletMap } from "~/components/LeafletMap";
 import { and, eq } from "drizzle-orm";
@@ -272,6 +273,56 @@ function EventDetailPage() {
     setRsvpSubmitting(false);
   }
 
+  const attendeeCount = rsvpData?.rsvpCounts?.accepted ?? data?.rsvpCounts?.accepted ?? 0;
+
+  const bottomBarContent = useMemo(() => {
+    if (!data) return null;
+    if (data.event.externalUrl) {
+      return (
+        <div className="mx-auto flex max-w-5xl items-center justify-center gap-4 px-6 py-3">
+          <Button size="sm" asChild>
+            <a href={data.event.externalUrl} target="_blank" rel="noopener noreferrer">
+              Register externally
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="size-4 ml-1">
+                <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 17h-8.5A2.25 2.25 0 0 1 2 14.75v-8.5A2.25 2.25 0 0 1 4.25 4h5a.75.75 0 0 1 0 1.5h-5Zm7.5-2.25a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-5.22 5.22a.75.75 0 1 1-1.06-1.06l5.22-5.22H12.5a.75.75 0 0 1-.75-.75Z" clipRule="evenodd" />
+              </svg>
+            </a>
+          </Button>
+        </div>
+      );
+    }
+    if (rsvpData) {
+      return (
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{attendeeCount} attending</span>
+            {rsvpData.userRsvp && (
+              <Badge variant={rsvpData.userRsvp.status === "accepted" ? "default" : "secondary"} className="text-xs">
+                {rsvpData.userRsvp.status === "accepted" ? "Going" : "Not going"}
+              </Badge>
+            )}
+          </div>
+          {!rsvpData.isAuthenticated ? (
+            <Button size="sm" asChild>
+              <Link to="/auth/signin">Sign in to RSVP</Link>
+            </Button>
+          ) : rsvpData.userRsvp ? (
+            <Button size="sm" variant="outline" onClick={() => setRsvpDialogOpen(true)}>
+              Change RSVP
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => setRsvpDialogOpen(true)}>
+              RSVP
+            </Button>
+          )}
+        </div>
+      );
+    }
+    return null;
+  }, [data, rsvpData, attendeeCount, setRsvpDialogOpen]);
+
+  useBottomBarSlot(bottomBarContent);
+
   if (loading) {
     return <p className="text-muted-foreground">Loading...</p>;
   }
@@ -332,8 +383,6 @@ function EventDetailPage() {
     : localSameDay
       ? `${localStartDate} ${localStartTime} — ${localEndTime}`
       : `${localStartDate} ${localStartTime} — ${localEndDate} ${localEndTime}`;
-
-  const attendeeCount = rsvpData?.rsvpCounts?.accepted ?? data.rsvpCounts?.accepted ?? 0;
 
   const [gradFrom, gradTo] = pickGradient(event.categoryId || event.id);
 
@@ -677,47 +726,6 @@ function EventDetailPage() {
         </div>
       </div>
 
-      {/* Mobile sticky bottom bar */}
-      {event.externalUrl ? (
-        <div className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-          <div className="mx-auto flex max-w-5xl items-center justify-center gap-4 px-6 py-3">
-            <Button size="sm" asChild>
-              <a href={event.externalUrl} target="_blank" rel="noopener noreferrer">
-                Register externally
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="size-4 ml-1">
-                  <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 17h-8.5A2.25 2.25 0 0 1 2 14.75v-8.5A2.25 2.25 0 0 1 4.25 4h5a.75.75 0 0 1 0 1.5h-5Zm7.5-2.25a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-5.22 5.22a.75.75 0 1 1-1.06-1.06l5.22-5.22H12.5a.75.75 0 0 1-.75-.75Z" clipRule="evenodd" />
-                </svg>
-              </a>
-            </Button>
-          </div>
-        </div>
-      ) : rsvpData ? (
-        <div className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-          <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium">{attendeeCount} attending</span>
-              {rsvpData.userRsvp && (
-                <Badge variant={rsvpData.userRsvp.status === "accepted" ? "default" : "secondary"} className="text-xs">
-                  {rsvpData.userRsvp.status === "accepted" ? "Going" : "Not going"}
-                </Badge>
-              )}
-            </div>
-            {!rsvpData.isAuthenticated ? (
-              <Button size="sm" asChild>
-                <Link to="/auth/signin">Sign in to RSVP</Link>
-              </Button>
-            ) : rsvpData.userRsvp ? (
-              <Button size="sm" variant="outline" onClick={() => setRsvpDialogOpen(true)}>
-                Change RSVP
-              </Button>
-            ) : (
-              <Button size="sm" onClick={() => setRsvpDialogOpen(true)}>
-                RSVP
-              </Button>
-            )}
-          </div>
-        </div>
-      ) : null}
 
       {/* Map Dialog */}
       {event.placeLatitude && event.placeLongitude && (


### PR DESCRIPTION
## Summary
- The mobile RSVP/register bar on event detail pages was hidden behind the bottom navigation bar due to overlapping fixed positioning and z-index conflicts.
- Introduces a bottom bar slot system in the root layout (`useBottomBarSlot` hook) that lets child pages inject content directly above the bottom nav, eliminating hardcoded offsets and z-index issues.
- The event detail page now uses this slot to render its RSVP bar, ensuring it's always visible above the navigation.

## Test plan
- [x] Open an event detail page on mobile (or narrow viewport) and verify the RSVP button bar appears above the bottom navigation
- [x] Verify the bar disappears when navigating away from the event detail page
- [x] Check that events with external URLs show the "Register externally" bar correctly
- [x] Verify desktop layout is unaffected (no bottom bar slot or nav shown)