### PR TITLE
Add markdown support for event descriptions and group posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fedify/h3": "^1.9.0",
     "@js-temporal/polyfill": "^0.5.1",
     "@lingui/core": "^5.9.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.0",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-router": "1.157.16",
@@ -38,6 +39,7 @@
     "h3-js": "^4.4.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.575.0",
+    "markdown-it": "^14.1.1",
     "nitro": "npm:nitro-nightly@3.0.1-20260223-102354-c0b46421",
     "pg": "^8.12.0",
     "posthog-js": "^1.356.1",
@@ -50,6 +52,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "^1.4.0",
+    "xss": "^1.0.15",
     "zod": "^3.24.2"
   },
   "pnpm": {
@@ -62,6 +65,7 @@
     "@lingui/vite-plugin": "^5.9.2",
     "@tanstack/router-devtools": "1.157.16",
     "@types/leaflet": "^1.9.21",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@lingui/core':
         specifier: ^5.9.2
         version: 5.9.2(@lingui/babel-plugin-lingui-macro@5.9.2(typescript@5.9.3))
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.0)
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.0(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -77,6 +80,9 @@ importers:
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.1.0)
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       nitro:
         specifier: npm:nitro-nightly@3.0.1-20260223-102354-c0b46421
         version: nitro-nightly@3.0.1-20260223-102354-c0b46421(drizzle-orm@0.38.4(@opentelemetry/api@1.9.0)(@types/react@19.2.14)(pg@8.18.0)(react@19.1.0))(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.58.0)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -113,6 +119,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      xss:
+        specifier: ^1.0.15
+        version: 1.0.15
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -129,6 +138,9 @@ importers:
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: ^22
         version: 22.19.11
@@ -2554,6 +2566,11 @@ packages:
     resolution: {integrity: sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.2.0':
     resolution: {integrity: sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA==}
     peerDependencies:
@@ -2788,6 +2805,15 @@ packages:
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -3021,6 +3047,9 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -3073,6 +3102,14 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  cssfilter@0.0.10:
+    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3750,6 +3787,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3808,6 +3848,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4041,6 +4088,10 @@ packages:
   point-in-polygon-hao@1.2.4:
     resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4091,6 +4142,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4401,6 +4456,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -4649,6 +4707,11 @@ packages:
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
     engines: {node: '>=20.0'}
+
+  xss@1.0.15:
+    resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7255,6 +7318,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.0
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.0)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.0
+
   '@tailwindcss/vite@4.2.0(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.0
@@ -7607,6 +7675,15 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.16
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -7875,6 +7952,8 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@2.20.3: {}
+
   concat-map@0.0.1: {}
 
   consola@3.4.2: {}
@@ -7921,6 +8000,10 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
+
+  cssfilter@0.0.10: {}
 
   csstype@3.2.3: {}
 
@@ -8519,6 +8602,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -8565,6 +8652,17 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -8812,6 +8910,11 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.2
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -8879,6 +8982,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -9264,6 +9369,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   ufo@1.6.3: {}
 
   uint8arrays@3.1.1:
@@ -9398,6 +9505,11 @@ snapshots:
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
       js-yaml: 4.1.1
+
+  xss@1.0.15:
+    dependencies:
+      commander: 2.20.3
+      cssfilter: 0.0.10
 
   xtend@4.0.2: {}
 

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,0 +1,65 @@
+import { useState, useId } from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "~/components/ui/tabs";
+import { Textarea } from "~/components/ui/textarea";
+import { Label } from "~/components/ui/label";
+import { renderMarkdown } from "~/lib/markdown";
+
+type MarkdownEditorProps = {
+  id?: string;
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  rows?: number;
+};
+
+export function MarkdownEditor({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder = "Supports Markdown formatting...",
+  rows = 6,
+}: MarkdownEditorProps) {
+  const fallbackId = useId();
+  const inputId = id ?? fallbackId;
+  const [activeTab, setActiveTab] = useState<string>("write");
+
+  return (
+    <div className="space-y-1.5">
+      {label && <Label htmlFor={inputId}>{label}</Label>}
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="write">Write</TabsTrigger>
+          <TabsTrigger value="preview">Preview</TabsTrigger>
+        </TabsList>
+        <TabsContent value="write" className="mt-2">
+          <Textarea
+            id={inputId}
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            rows={rows}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Markdown supported: **bold**, *italic*, [links](url), lists, headings
+          </p>
+        </TabsContent>
+        <TabsContent value="preview" className="mt-2">
+          <div className="min-h-[120px] rounded-md border px-3 py-2">
+            {value.trim() ? (
+              <div
+                className="prose prose-sm max-w-none dark:prose-invert"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(value) }}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground italic">
+                Nothing to preview
+              </p>
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,70 @@
+import MarkdownIt from "markdown-it";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import xssModule from "xss";
+
+const { FilterXSS, getDefaultWhiteList } =
+  xssModule as unknown as typeof import("xss");
+
+const md = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: true,
+  typographer: false,
+});
+
+const xssFilter = new FilterXSS({
+  whiteList: {
+    ...getDefaultWhiteList(),
+    h1: [],
+    h2: [],
+    h3: [],
+    h4: [],
+    h5: [],
+    h6: [],
+    p: [],
+    br: [],
+    strong: [],
+    b: [],
+    em: [],
+    i: [],
+    u: [],
+    s: [],
+    del: [],
+    ul: [],
+    ol: [],
+    li: [],
+    blockquote: [],
+    pre: [],
+    code: ["class"],
+    a: ["href", "title", "target", "rel"],
+    img: ["src", "alt", "title"],
+    hr: [],
+    table: [],
+    thead: [],
+    tbody: [],
+    tr: [],
+    th: [],
+    td: [],
+  },
+  onTagAttr(tag: string, name: string, value: string) {
+    if (tag === "a" && name === "href") {
+      if (/^(?:https?:|mailto:)/i.test(value) || value.startsWith("/")) {
+        return `href="${value}" target="_blank" rel="noopener noreferrer"`;
+      }
+      return "";
+    }
+    if (tag === "code" && name === "class") {
+      if (/^language-[\w-]+$/.test(value)) {
+        return `class="${value}"`;
+      }
+      return "";
+    }
+  },
+  stripIgnoreTag: true,
+});
+
+export function renderMarkdown(source: string | null | undefined): string {
+  if (!source || !source.trim()) return "";
+  const rawHtml = md.render(source);
+  return xssFilter.process(rawHtml);
+}

--- a/src/routes/events/$eventId/dashboard/edit.tsx
+++ b/src/routes/events/$eventId/dashboard/edit.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from "react";
 import { useEventCategories } from "~/hooks/useEventCategories";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
-import { Textarea } from "~/components/ui/textarea";
+import { MarkdownEditor } from "~/components/MarkdownEditor";
 import { Label } from "~/components/ui/label";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -294,15 +294,13 @@ function EditTab() {
         </div>
 
         {/* Description */}
-        <div className="space-y-1.5">
-          <Label htmlFor="description">Description</Label>
-          <Textarea
-            id="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            rows={4}
-          />
-        </div>
+        <MarkdownEditor
+          id="description"
+          label="Description"
+          value={description}
+          onChange={setDescription}
+          rows={6}
+        />
 
         {/* Category */}
         <div className="space-y-1.5">

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -10,6 +10,7 @@ import { db } from "~/server/db/client";
 import { events, actors, users, userFediverseAccounts } from "~/server/db/schema";
 import { useEventCategoryMap } from "~/hooks/useEventCategories";
 import { pickGradient } from "~/shared/gradients";
+import { renderMarkdown } from "~/lib/markdown";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import {
@@ -651,9 +652,10 @@ function EventDetailPage() {
                 <CardTitle className="text-base">About</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-                  {event.description}
-                </p>
+                <div
+                  className="prose prose-sm max-w-none dark:prose-invert text-muted-foreground"
+                  dangerouslySetInnerHTML={{ __html: renderMarkdown(event.description) }}
+                />
               </CardContent>
             </Card>
           )}

--- a/src/routes/events/create.tsx
+++ b/src/routes/events/create.tsx
@@ -4,7 +4,7 @@ import { usePostHog } from "posthog-js/react";
 import { useEventCategories } from "~/hooks/useEventCategories";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
-import { Textarea } from "~/components/ui/textarea";
+import { MarkdownEditor } from "~/components/MarkdownEditor";
 import { Label } from "~/components/ui/label";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
@@ -434,16 +434,14 @@ function CreateEventPage() {
               </Alert>
 
               {/* Description */}
-              <div className="space-y-1.5">
-                <Label htmlFor="description">Description</Label>
-                <Textarea
-                  id="description"
-                  placeholder="What is this event about?"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  rows={4}
-                />
-              </div>
+              <MarkdownEditor
+                id="description"
+                label="Description"
+                value={description}
+                onChange={setDescription}
+                placeholder="What is this event about?"
+                rows={6}
+              />
 
               {/* Header Image */}
               <div className="space-y-1.5">

--- a/src/routes/groups/$identifier/dashboard.tsx
+++ b/src/routes/groups/$identifier/dashboard.tsx
@@ -21,6 +21,7 @@ import {
   DialogTitle,
 } from "~/components/ui/dialog";
 import { Textarea } from "~/components/ui/textarea";
+import { MarkdownEditor } from "~/components/MarkdownEditor";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { Alert, AlertDescription } from "~/components/ui/alert";
@@ -590,10 +591,10 @@ function GroupDashboard() {
             </Alert>
           )}
 
-          <Textarea
-            placeholder="What's happening?"
+          <MarkdownEditor
             value={noteContent}
-            onChange={(e) => setNoteContent(e.target.value)}
+            onChange={setNoteContent}
+            placeholder="What's happening?"
             rows={4}
           />
 

--- a/src/routes/groups/$identifier/index.tsx
+++ b/src/routes/groups/$identifier/index.tsx
@@ -15,6 +15,7 @@ import { Badge } from "~/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 import { RemoteFollowDialog } from "~/components/RemoteFollowDialog";
 import { Calendar, BadgeCheck } from "lucide-react";
+import { renderMarkdown } from "~/lib/markdown";
 
 const getGroupMeta = createServerFn({ method: "GET" })
   .inputValidator(zodValidator(z.object({ handle: z.string() })))
@@ -386,7 +387,7 @@ function TimelineEvent({
 
           {event.description && (
             <p className="text-sm text-muted-foreground line-clamp-2">
-              {event.description}
+              {event.description.replace(/[#*_`~\[\]()>!|-]/g, "").trim()}
             </p>
           )}
         </div>
@@ -416,7 +417,7 @@ function TimelineNote({
 
         <div className="rounded-lg border p-4 space-y-2">
           <div
-            className="text-sm leading-relaxed [&>p]:mb-2 [&>p:last-child]:mb-0"
+            className="prose prose-sm max-w-none dark:prose-invert"
             dangerouslySetInnerHTML={{ __html: note.content }}
           />
 

--- a/src/routes/groups/-create-note.ts
+++ b/src/routes/groups/-create-note.ts
@@ -3,6 +3,7 @@ import { db } from "~/server/db/client";
 import { actors, groupMembers } from "~/server/db/schema";
 import { getSessionUser } from "~/server/auth";
 import { createAndDeliverNote } from "~/server/fediverse/group";
+import { renderMarkdown } from "~/lib/markdown";
 
 export const POST = async ({ request }: { request: Request }) => {
   const user = await getSessionUser(request);
@@ -52,12 +53,7 @@ export const POST = async ({ request }: { request: Request }) => {
   }
 
   try {
-    // Wrap plain text in <p> tags
-    const htmlContent = body.content
-      .trim()
-      .split(/\n\n+/)
-      .map((p) => `<p>${p.replace(/\n/g, "<br>")}</p>`)
-      .join("");
+    const htmlContent = renderMarkdown(body.content);
 
     const post = await createAndDeliverNote(group.handle, htmlContent);
 

--- a/src/server/fediverse/category.ts
+++ b/src/server/fediverse/category.ts
@@ -7,6 +7,7 @@ import { getI18n, resolveLocale } from "~/server/i18n";
 import { resolveTimezone, formatEventDateRange } from "~/server/timezone";
 import { getEventCategory } from "~/server/events/categories";
 import { getFederationContext } from "./federation";
+import { renderMarkdown } from "~/lib/markdown";
 
 /**
  * Get the feed actor handle for a category.
@@ -201,7 +202,7 @@ export async function announceEvent(
   const dateRangeStr = formatEventDateRange(event.startsAt, event.endsAt, tz);
   const eventUrl = new URL(`/events/${event.id}`, ctx.canonicalOrigin).href;
   const descHtml = event.description
-    ? `<p>${event.description}</p>`
+    ? renderMarkdown(event.description)
     : "";
 
   let content: string;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary

- Add markdown editing with live preview (Write/Preview tabs) for event descriptions and group posts using `markdown-it` for rendering and `xss` for sanitization
- Render markdown HTML on event detail pages, group timelines, and federated ActivityPub Notes with `@tailwindcss/typography` prose styling
- No schema changes needed — raw markdown is stored as-is in the existing `description` field; group posts continue storing rendered HTML in `posts.content`

Closes #72

## Test plan
- [x] Create an event with markdown formatting (headings, bold, links, lists, code blocks) and verify the preview tab renders correctly
- [x] View the event detail page and confirm rendered HTML with proper prose styling
- [x] Edit the event and verify markdown loads in the editor with working preview
- [x] Create a group post with markdown and verify it renders on the group timeline and note detail page
- [x] Enter `<script>alert(1)</script>` in both event description and group post — confirm XSS is blocked
- [x] Verify existing plain text event descriptions still display correctly (line breaks preserved)
- [x] Verify dark mode renders correctly with `prose-invert`
- [x] Run `pnpm typecheck` — passes (no new errors)