### PR TITLE
Filter event categories by enabled status

### DIFF
--- a/src/hooks/useEventCategories.ts
+++ b/src/hooks/useEventCategories.ts
@@ -5,6 +5,7 @@ export type EventCategoryOption = {
   label: string;
   emoji: string | null;
   description: string | null;
+  enabled: boolean;
 };
 
 let cachedCategories: EventCategoryOption[] | null = null;
@@ -16,7 +17,9 @@ function fetchCategories(): Promise<EventCategoryOption[]> {
   fetchPromise = fetch("/api/event-categories")
     .then((r) => r.json())
     .then((data) => {
-      cachedCategories = data.categories ?? [];
+      cachedCategories = (data.categories ?? []).filter(
+        (c: EventCategoryOption) => c.enabled,
+      );
       fetchPromise = null;
       return cachedCategories!;
     })


### PR DESCRIPTION
## Summary
Add client-side filtering in the `useEventCategories` hook to only return enabled categories. The `enabled` field is added to the `EventCategoryOption` type, and fetched categories are filtered by `enabled` before caching. This provides defense-in-depth alongside the existing server-side filtering in `getEventCategories`.

## Test plan
- [x] Verify categories page only shows enabled categories
- [x] Verify event create/edit forms only list enabled category options
- [x] Disable a category via admin and confirm it no longer appears in the UI