### PR TITLE
Sort event categories by sortOrder in hook

### DIFF
--- a/src/hooks/useEventCategories.ts
+++ b/src/hooks/useEventCategories.ts
@@ -5,6 +5,7 @@ export type EventCategoryOption = {
   label: string;
   emoji: string | null;
   description: string | null;
+  sortOrder: number;
   enabled: boolean;
 };
 
@@ -17,9 +18,12 @@ function fetchCategories(): Promise<EventCategoryOption[]> {
   fetchPromise = fetch("/api/event-categories")
     .then((r) => r.json())
     .then((data) => {
-      cachedCategories = (data.categories ?? []).filter(
-        (c: EventCategoryOption) => c.enabled,
-      );
+      cachedCategories = (data.categories ?? [])
+        .filter((c: EventCategoryOption) => c.enabled)
+        .sort(
+          (a: EventCategoryOption, b: EventCategoryOption) =>
+            a.sortOrder - b.sortOrder || a.label.localeCompare(b.label),
+        );
       fetchPromise = null;
       return cachedCategories!;
     })


### PR DESCRIPTION
## Summary
- Add `sortOrder` field to the `EventCategoryOption` type in `useEventCategories`
- Sort fetched categories client-side by `sortOrder` (ascending) then `label` (alphabetical), matching the server-side query ordering

## Test plan
- [x] Verify event categories appear in the correct sort order in category dropdowns/selectors
- [x] Confirm categories with lower `sortOrder` values appear first
- [x] Verify categories with the same `sortOrder` are sorted alphabetically by label