### PR TITLE
Add remote discussion on event page

### DIFF
--- a/src/components/RemoteDiscussionDialog.tsx
+++ b/src/components/RemoteDiscussionDialog.tsx
@@ -1,0 +1,176 @@
+import { type ReactNode, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+export function RemoteDiscussionDialog({
+  apUrl,
+  triggerLabel = "Discuss on your instance",
+  variant = "button",
+  className,
+}: {
+  apUrl: string;
+  triggerLabel?: ReactNode;
+  variant?: "button" | "link" | "ghost";
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [handle, setHandle] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [interactionUrl, setInteractionUrl] = useState<string | null>(null);
+  const [domain, setDomain] = useState<string | null>(null);
+
+  const handleLookup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const input = handle.trim();
+    if (!input) {
+      setError("Please enter your fediverse handle.");
+      return;
+    }
+
+    if (!/^@?[^@]+@[^@]+\.[^@]+$/.test(input)) {
+      setError("Invalid format. Use @username@domain.com");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/instance-lookup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle: input }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Lookup failed.");
+      }
+
+      const url = data.interactionTemplate.replace(
+        "{uri}",
+        encodeURIComponent(apUrl),
+      );
+      setInteractionUrl(url);
+      setDomain(data.domain);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Lookup failed.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleGo = () => {
+    if (!interactionUrl) return;
+    window.open(interactionUrl, "_blank", "noopener,noreferrer");
+    setOpen(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setHandle("");
+      setError("");
+      setInteractionUrl(null);
+      setDomain(null);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        {variant === "link" ? (
+          <button
+            type="button"
+            className={`text-xs text-muted-foreground hover:text-foreground hover:underline cursor-pointer ${className ?? ""}`}
+          >
+            {triggerLabel}
+          </button>
+        ) : variant === "ghost" ? (
+          <Button variant="ghost" size="sm" className={`h-auto px-1.5 py-0.5 text-xs text-muted-foreground gap-1 ${className ?? ""}`}>
+            {triggerLabel}
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" className={className}>
+            {triggerLabel}
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Join the Discussion</DialogTitle>
+          <DialogDescription>
+            If you want to continue this discussion, enter your fediverse handle
+            to find this post on your instance.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!interactionUrl ? (
+          <form onSubmit={handleLookup} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="remoteDiscussHandle">
+                Your fediverse handle
+              </Label>
+              <Input
+                id="remoteDiscussHandle"
+                placeholder="@username@mastodon.social"
+                value={handle}
+                onChange={(e) => {
+                  setHandle(e.target.value);
+                  if (error) setError("");
+                }}
+                disabled={loading}
+              />
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? "Looking up..." : "Look up"}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              You will be redirected to <strong>{domain}</strong> to find and
+              reply to this post.
+            </p>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <div className="flex gap-2 justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setInteractionUrl(null);
+                  setDomain(null);
+                  setError("");
+                }}
+              >
+                Back
+              </Button>
+              <Button onClick={handleGo}>Go to my instance</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -33,6 +33,8 @@ import { Separator } from "~/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/ui/tooltip";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 import { usePostHog } from "posthog-js/react";
+import { ExternalLink } from "lucide-react";
+import { RemoteDiscussionDialog } from "~/components/RemoteDiscussionDialog";
 
 const getEventMeta = createServerFn({ method: "GET" })
   .inputValidator(zodValidator(z.object({ eventId: z.string() })))
@@ -245,6 +247,7 @@ function EventDetailPage() {
     published: string;
     createdAt: string;
     lastRepliedAt: string | null;
+    apUrl: string | null;
     actorHandle: string;
     actorName: string | null;
     actorAvatarUrl: string | null;
@@ -256,6 +259,7 @@ function EventDetailPage() {
     content: string;
     createdAt: string;
     inReplyToPostId: string | null;
+    apUrl: string | null;
     actorHandle: string;
     actorName: string | null;
     actorAvatarUrl: string | null;
@@ -266,6 +270,7 @@ function EventDetailPage() {
   const [threadCache, setThreadCache] = useState<Record<string, ThreadMessage[]>>({});
   const [threadLoading, setThreadLoading] = useState<string | null>(null);
   const isGroupEvent = !!data?.event?.groupHandle;
+  const eventNoteApUrl = (data as { eventNoteApUrl?: string | null } | null)?.eventNoteApUrl ?? null;
 
   useEffect(() => {
     if (!isGroupEvent) return;
@@ -748,111 +753,147 @@ function EventDetailPage() {
           )}
 
           {/* Public Discussions */}
-          {isGroupEvent && publicInquiries.length > 0 && (
+          {isGroupEvent && (
             <Card className="rounded-lg">
               <CardHeader>
-                <CardTitle className="text-base">Discussion</CardTitle>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">Discussion</CardTitle>
+                  {eventNoteApUrl && publicInquiries.length > 0 && (
+                    <RemoteDiscussionDialog apUrl={eventNoteApUrl} />
+                  )}
+                </div>
               </CardHeader>
               <CardContent>
-                <ul className="divide-y">
-                  {publicInquiries.map((inq) => {
-                    const isExpanded = expandedId === inq.id;
-                    const replies = threadCache[inq.id];
-                    const isLoading = threadLoading === inq.id;
+                {publicInquiries.length === 0 ? (
+                  <div className="flex flex-col items-center gap-3 py-4 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      No discussions yet.
+                    </p>
+                    {eventNoteApUrl && (
+                      <RemoteDiscussionDialog apUrl={eventNoteApUrl} />
+                    )}
+                  </div>
+                ) : (
+                  <ul className="divide-y">
+                    {publicInquiries.map((inq) => {
+                      const isExpanded = expandedId === inq.id;
+                      const replies = threadCache[inq.id];
+                      const isLoading = threadLoading === inq.id;
 
-                    return (
-                      <li key={inq.id} className="py-3 first:pt-0 last:pb-0">
-                        <button
-                          type="button"
-                          className="w-full text-left"
-                          onClick={() => toggleThread(inq.id)}
-                        >
-                          <div className="flex items-start gap-3">
-                            {inq.actorAvatarUrl ? (
-                              <img
-                                src={inq.actorAvatarUrl}
-                                alt=""
-                                className="size-8 rounded-full shrink-0"
-                              />
-                            ) : (
-                              <div className="size-8 rounded-full bg-muted flex items-center justify-center text-xs font-semibold shrink-0">
-                                {(inq.actorName ?? inq.actorHandle)?.[0]?.toUpperCase()}
-                              </div>
-                            )}
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-baseline gap-1.5">
-                                <span className="text-sm font-medium truncate">
-                                  {inq.actorName ?? inq.actorHandle}
-                                </span>
-                                <span className="text-xs text-muted-foreground truncate">
-                                  @{inq.actorHandle}{inq.actorDomain && !inq.actorHandle.includes("@") ? `@${inq.actorDomain}` : ""}
-                                </span>
-                                <span className="text-xs text-muted-foreground ml-auto shrink-0">
-                                  {formatRelativeTime(inq.lastRepliedAt ?? inq.createdAt)}
-                                </span>
-                              </div>
-                              <div
-                                className="text-sm text-muted-foreground mt-1 line-clamp-3 prose prose-sm max-w-none [&_p]:my-0.5"
-                                dangerouslySetInnerHTML={{ __html: stripMentionHtml(inq.content) }}
-                              />
-                              {inq.replyCount > 0 && (
-                                <p className="text-xs text-primary mt-1.5">
-                                  {isExpanded ? "Hide" : "Show"} {inq.replyCount} {inq.replyCount === 1 ? "reply" : "replies"}
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </button>
-
-                        {/* Expanded thread */}
-                        {isExpanded && (
-                          <div className="mt-3 ml-11 divide-y">
-                            {isLoading ? (
-                              <p className="text-xs text-muted-foreground py-2">Loading...</p>
-                            ) : replies ? (
-                              buildThreadTree(replies, inq.id).map(({ msg: m, depth }) => (
-                                <div
-                                  key={m.id}
-                                  className="flex items-start gap-2 py-2"
-                                  style={{ paddingLeft: `${Math.min(depth, 4) * 16}px` }}
-                                >
-                                  {m.actorAvatarUrl ? (
-                                    <img
-                                      src={m.actorAvatarUrl}
-                                      alt=""
-                                      className="size-5 rounded-full shrink-0 mt-0.5"
-                                    />
-                                  ) : (
-                                    <div className="size-5 rounded-full bg-muted flex items-center justify-center text-[10px] font-semibold shrink-0 mt-0.5">
-                                      {(m.actorName ?? m.actorHandle)?.[0]?.toUpperCase()}
-                                    </div>
-                                  )}
-                                  <div className="min-w-0 flex-1">
-                                    <div className="flex items-baseline gap-1.5 flex-wrap">
-                                      <span className="text-xs font-semibold">
-                                        {m.actorName ?? m.actorHandle}
-                                      </span>
-                                      <span className="text-[10px] text-muted-foreground">
-                                        @{m.actorHandle}{m.actorDomain && !m.actorHandle.includes("@") ? `@${m.actorDomain}` : ""}
-                                      </span>
-                                      <span className="text-[10px] text-muted-foreground">
-                                        {formatRelativeTime(m.createdAt)}
-                                      </span>
-                                    </div>
-                                    <div
-                                      className="text-xs text-muted-foreground mt-0.5 prose prose-xs max-w-none [&_p]:my-0.5"
-                                      dangerouslySetInnerHTML={{ __html: stripMentionHtml(m.content) }}
-                                    />
-                                  </div>
+                      return (
+                        <li key={inq.id} className="group/inq py-3 first:pt-0 last:pb-0">
+                          <button
+                            type="button"
+                            className="w-full text-left"
+                            onClick={() => inq.replyCount > 0 && toggleThread(inq.id)}
+                          >
+                            <div className="flex items-start gap-3">
+                              {inq.actorAvatarUrl ? (
+                                <img
+                                  src={inq.actorAvatarUrl}
+                                  alt=""
+                                  className="size-8 rounded-full shrink-0"
+                                />
+                              ) : (
+                                <div className="size-8 rounded-full bg-muted flex items-center justify-center text-xs font-semibold shrink-0">
+                                  {(inq.actorName ?? inq.actorHandle)?.[0]?.toUpperCase()}
                                 </div>
-                              ))
-                            ) : null}
-                          </div>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
+                              )}
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-baseline gap-1.5">
+                                  <span className="text-sm font-medium truncate">
+                                    {inq.actorName ?? inq.actorHandle}
+                                  </span>
+                                  <span className="text-xs text-muted-foreground truncate">
+                                    @{inq.actorHandle}{inq.actorDomain && !inq.actorHandle.includes("@") ? `@${inq.actorDomain}` : ""}
+                                  </span>
+                                  <span className="text-xs text-muted-foreground ml-auto shrink-0">
+                                    {formatRelativeTime(inq.lastRepliedAt ?? inq.createdAt)}
+                                  </span>
+                                </div>
+                                <div className="flex items-start gap-2 mt-1">
+                                  <div
+                                    className="text-sm text-muted-foreground line-clamp-3 prose prose-sm max-w-none [&_p]:my-0.5 flex-1 min-w-0"
+                                    dangerouslySetInnerHTML={{ __html: stripMentionHtml(inq.content) }}
+                                  />
+                                  {inq.apUrl && (
+                                    <span className="shrink-0 opacity-0 group-hover/inq:opacity-100 transition-opacity">
+                                      <RemoteDiscussionDialog
+                                        apUrl={inq.apUrl}
+                                        triggerLabel={<><ExternalLink className="size-3" /> Reply</>}
+                                        variant="ghost"
+                                      />
+                                    </span>
+                                  )}
+                                </div>
+                                {inq.replyCount > 0 && (
+                                  <p className="text-xs text-primary mt-1.5">
+                                    {isExpanded ? "Hide" : "Show"} {inq.replyCount} {inq.replyCount === 1 ? "reply" : "replies"}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </button>
+
+                          {/* Expanded thread */}
+                          {isExpanded && (
+                            <div className="mt-3 ml-11 divide-y">
+                              {isLoading ? (
+                                <p className="text-xs text-muted-foreground py-2">Loading...</p>
+                              ) : replies ? (
+                                buildThreadTree(replies, inq.id).map(({ msg: m, depth }) => (
+                                  <div
+                                    key={m.id}
+                                    className="group/reply flex items-start gap-2 py-2"
+                                    style={{ paddingLeft: `${Math.min(depth, 4) * 16}px` }}
+                                  >
+                                    {m.actorAvatarUrl ? (
+                                      <img
+                                        src={m.actorAvatarUrl}
+                                        alt=""
+                                        className="size-5 rounded-full shrink-0 mt-0.5"
+                                      />
+                                    ) : (
+                                      <div className="size-5 rounded-full bg-muted flex items-center justify-center text-[10px] font-semibold shrink-0 mt-0.5">
+                                        {(m.actorName ?? m.actorHandle)?.[0]?.toUpperCase()}
+                                      </div>
+                                    )}
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex items-baseline gap-1.5 flex-wrap">
+                                        <span className="text-xs font-semibold">
+                                          {m.actorName ?? m.actorHandle}
+                                        </span>
+                                        <span className="text-[10px] text-muted-foreground">
+                                          @{m.actorHandle}{m.actorDomain && !m.actorHandle.includes("@") ? `@${m.actorDomain}` : ""}
+                                        </span>
+                                        <span className="text-[10px] text-muted-foreground">
+                                          {formatRelativeTime(m.createdAt)}
+                                        </span>
+                                        {m.apUrl && (
+                                          <span className="opacity-0 group-hover/reply:opacity-100 transition-opacity">
+                                            <RemoteDiscussionDialog
+                                              apUrl={m.apUrl}
+                                              triggerLabel={<><ExternalLink className="size-3" /> Reply</>}
+                                              variant="ghost"
+                                            />
+                                          </span>
+                                        )}
+                                      </div>
+                                      <div
+                                        className="text-xs text-muted-foreground mt-0.5 prose prose-xs max-w-none [&_p]:my-0.5"
+                                        dangerouslySetInnerHTML={{ __html: stripMentionHtml(m.content) }}
+                                      />
+                                    </div>
+                                  </div>
+                                ))
+                              ) : null}
+                            </div>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
               </CardContent>
             </Card>
           )}

--- a/src/routes/events/-detail.ts
+++ b/src/routes/events/-detail.ts
@@ -1,7 +1,8 @@
 import { aliasedTable, and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "~/server/db/client";
-import { events, actors, eventOrganizers, eventTiers, groupMembers, rsvps, eventQuestions, rsvpAnswers, users, places, userFediverseAccounts } from "~/server/db/schema";
+import { events, actors, eventOrganizers, eventTiers, groupMembers, rsvps, eventQuestions, rsvpAnswers, users, places, userFediverseAccounts, posts } from "~/server/db/schema";
 import { getSessionUser } from "~/server/auth";
+import { env } from "~/server/env";
 
 export const GET = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -185,6 +186,26 @@ export const GET = async ({ request }: { request: Request }) => {
     }
   }
 
+  // Get event note AP URL (the post created when event is published)
+  let eventNoteApUrl: string | null = null;
+  if (event.published) {
+    const [eventNote] = await db
+      .select({ id: posts.id })
+      .from(posts)
+      .where(
+        and(
+          eq(posts.eventId, eventId),
+          isNull(posts.inReplyToPostId),
+          isNull(posts.threadRootId),
+          isNull(posts.threadStatus),
+        ),
+      )
+      .limit(1);
+    if (eventNote) {
+      eventNoteApUrl = `${env.baseUrl}/ap/notes/${eventNote.id}`;
+    }
+  }
+
   return Response.json({
     event,
     organizers,
@@ -193,5 +214,6 @@ export const GET = async ({ request }: { request: Request }) => {
     questions,
     tiers,
     canEdit,
+    eventNoteApUrl,
   });
 };

--- a/src/routes/events/-discussion-detail-public.ts
+++ b/src/routes/events/-discussion-detail-public.ts
@@ -1,6 +1,7 @@
 import { eq, and, or, sql } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { events, actors, posts } from "~/server/db/schema";
+import { env } from "~/server/env";
 
 export const GET = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -53,6 +54,7 @@ export const GET = async ({ request }: { request: Request }) => {
       content: posts.content,
       createdAt: posts.createdAt,
       inReplyToPostId: posts.inReplyToPostId,
+      apUri: posts.apUri,
       actorHandle: actors.handle,
       actorName: actors.name,
       actorAvatarUrl: actors.avatarUrl,
@@ -68,5 +70,10 @@ export const GET = async ({ request }: { request: Request }) => {
     )
     .orderBy(sql`${posts.createdAt} ASC`);
 
-  return Response.json({ messages });
+  const messagesWithApUrl = messages.map((m) => ({
+    ...m,
+    apUrl: m.apUri ?? `${env.baseUrl}/ap/notes/${m.id}`,
+  }));
+
+  return Response.json({ messages: messagesWithApUrl });
 };

--- a/src/routes/events/-discussions-public.ts
+++ b/src/routes/events/-discussions-public.ts
@@ -1,6 +1,7 @@
 import { eq, and, or, sql, isNull, isNotNull } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { events, actors, posts } from "~/server/db/schema";
+import { env } from "~/server/env";
 
 export const GET = async ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -58,6 +59,7 @@ export const GET = async ({ request }: { request: Request }) => {
       createdAt: posts.createdAt,
       threadStatus: posts.threadStatus,
       lastRepliedAt: posts.lastRepliedAt,
+      apUri: posts.apUri,
       actorHandle: actors.handle,
       actorName: actors.name,
       actorAvatarUrl: actors.avatarUrl,
@@ -83,5 +85,11 @@ export const GET = async ({ request }: { request: Request }) => {
     .limit(limit)
     .offset(offset);
 
-  return Response.json({ inquiries, total });
+  // Resolve AP URIs: remote posts have apUri set, local posts construct from id
+  const inquiriesWithApUrl = inquiries.map((inq) => ({
+    ...inq,
+    apUrl: inq.apUri ?? `${env.baseUrl}/ap/notes/${inq.id}`,
+  }));
+
+  return Response.json({ inquiries: inquiriesWithApUrl, total });
 };


### PR DESCRIPTION
## Summary
Enable fediverse users to reply to event discussions directly from their own instance using WebFinger-based instance discovery. The discussion section now always shows for group events (even with 0 inquiries), with a "Discuss on your instance" button. Each inquiry and threaded reply exposes an AP URL, allowing per-thread "Reply on your instance" actions with hover-to-reveal UX for a clean layout.

Changes:
- New `RemoteDiscussionDialog` component with button/ghost/link trigger variants
- Event detail API now returns `eventNoteApUrl` for the published event note
- Public discussions and thread detail APIs now include `apUrl` for each post
- Discussion section visible for all group events with empty state + trigger

### Screenshots

<img width="1076" height="821" alt="스크린샷 2026-03-14 23 00 56" src="https://github.com/user-attachments/assets/e316e13a-a079-4664-9f99-b3ff89f02128" />
<img width="676" height="756" alt="스크린샷 2026-03-14 23 01 08" src="https://github.com/user-attachments/assets/621e47f2-3779-4f25-94f0-73bed77544cc" />
