### PR TITLE
Fix mention href mismatch for merged accounts

### DIFF
--- a/src/routes/events/-create.ts
+++ b/src/routes/events/-create.ts
@@ -1,6 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { db } from "~/server/db/client";
-import { actors, events, eventOrganizers, eventQuestions, eventTiers, groupMembers, places } from "~/server/db/schema";
+import { actors, events, eventOrganizers, eventQuestions, eventTiers, groupMembers, places, userFediverseAccounts } from "~/server/db/schema";
 import { getSessionUser } from "~/server/auth";
 import { persistRemoteActor } from "~/server/fediverse/resolve";
 import { announceEvent } from "~/server/fediverse/category";
@@ -193,7 +193,15 @@ export const POST = async ({ request }: { request: Request }) => {
       const [remoteActor] = await db
         .select({ handle: actors.handle, actorUrl: actors.actorUrl, inboxUrl: actors.inboxUrl })
         .from(actors)
-        .where(and(eq(actors.userId, user.id), eq(actors.isLocal, false)))
+        .innerJoin(
+          userFediverseAccounts,
+          eq(actors.handle, userFediverseAccounts.fediverseHandle),
+        )
+        .where(and(
+          eq(actors.userId, user.id),
+          eq(actors.isLocal, false),
+          eq(userFediverseAccounts.isPrimary, true),
+        ))
         .limit(1);
       if (remoteActor?.inboxUrl) {
         creatorMention = { handle: remoteActor.handle, actorUrl: remoteActor.actorUrl, inboxUrl: remoteActor.inboxUrl };

--- a/src/routes/events/-publish.ts
+++ b/src/routes/events/-publish.ts
@@ -1,6 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { db } from "~/server/db/client";
-import { actors, events, eventOrganizers, groupMembers } from "~/server/db/schema";
+import { actors, events, eventOrganizers, groupMembers, userFediverseAccounts } from "~/server/db/schema";
 import { getSessionUser } from "~/server/auth";
 import { announceEvent } from "~/server/fediverse/category";
 
@@ -106,7 +106,15 @@ export const POST = async ({ request }: { request: Request }) => {
         const [remoteActor] = await db
           .select({ handle: actors.handle, actorUrl: actors.actorUrl, inboxUrl: actors.inboxUrl })
           .from(actors)
-          .where(and(eq(actors.userId, user.id), eq(actors.isLocal, false)))
+          .innerJoin(
+            userFediverseAccounts,
+            eq(actors.handle, userFediverseAccounts.fediverseHandle),
+          )
+          .where(and(
+            eq(actors.userId, user.id),
+            eq(actors.isLocal, false),
+            eq(userFediverseAccounts.isPrimary, true),
+          ))
           .limit(1);
         if (remoteActor?.inboxUrl) {
           creatorMention = { handle: remoteActor.handle, actorUrl: remoteActor.actorUrl, inboxUrl: remoteActor.inboxUrl };

--- a/src/server/fediverse/checkin.ts
+++ b/src/server/fediverse/checkin.ts
@@ -27,7 +27,16 @@ export async function postCheckin(
     db
       .select({ actorUrl: actors.actorUrl, inboxUrl: actors.inboxUrl })
       .from(actors)
-      .where(and(eq(actors.userId, userId), eq(actors.type, "Person"), eq(actors.isLocal, false)))
+      .innerJoin(
+        userFediverseAccounts,
+        eq(actors.handle, userFediverseAccounts.fediverseHandle),
+      )
+      .where(and(
+        eq(actors.userId, userId),
+        eq(actors.type, "Person"),
+        eq(actors.isLocal, false),
+        eq(userFediverseAccounts.isPrimary, true),
+      ))
       .limit(1),
     db
       .select({ fediverseHandle: userFediverseAccounts.fediverseHandle })


### PR DESCRIPTION
## Summary

When a user has multiple merged fediverse accounts, mention links in checkin notes and event announcements could point to the wrong actor. The remote actor query used `limit(1)` without filtering by the primary account, so it picked an arbitrary remote actor — causing the mention label (e.g., `@user@hollo.social`) to link to a different actor (e.g., Hackers' Pub).

Fixed by joining the remote actor query with `userFediverseAccounts` filtered by `isPrimary=true` in three files: `checkin.ts`, `-create.ts`, and `-publish.ts`.