### PR TITLE
Add public attendee preview on event page

### DIFF
--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -33,7 +33,7 @@ import { Separator } from "~/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/ui/tooltip";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 import { usePostHog } from "posthog-js/react";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Users } from "lucide-react";
 import { RemoteDiscussionDialog } from "~/components/RemoteDiscussionDialog";
 
 const getEventMeta = createServerFn({ method: "GET" })
@@ -134,6 +134,7 @@ type EventData = {
     isLocal: boolean;
   }[];
   rsvpCounts: { accepted: number; declined: number };
+  attendeePreview: { displayName: string; avatarUrl: string | null }[];
   questionCount: number;
   canEdit: boolean;
 };
@@ -612,6 +613,42 @@ function EventDetailPage() {
                 />
               </button>
             )}
+          </div>
+        )}
+
+        {/* Attendee preview */}
+        {data?.attendeePreview && data.attendeePreview.length > 0 && (
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 size-5 shrink-0 text-muted-foreground">
+              <Users className="size-5" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center">
+                {data.attendeePreview.map((a, i) => (
+                  <Avatar
+                    key={i}
+                    className={`size-7 border-2 border-background ${i > 0 ? "-ml-2" : ""}`}
+                  >
+                    {a.avatarUrl ? (
+                      <AvatarImage src={a.avatarUrl} alt={a.displayName} />
+                    ) : null}
+                    <AvatarFallback className="text-xs">
+                      {a.displayName.charAt(0).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                ))}
+                {attendeeCount > 5 && (
+                  <span className="ml-1.5 text-xs text-muted-foreground">
+                    +{attendeeCount - 5}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {attendeeCount <= 3
+                  ? data.attendeePreview.map((a) => a.displayName).join(", ")
+                  : `${data.attendeePreview.slice(0, 3).map((a) => a.displayName).join(", ")} and ${attendeeCount - 3} others`}
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/routes/events/-detail.ts
+++ b/src/routes/events/-detail.ts
@@ -119,6 +119,18 @@ export const GET = async ({ request }: { request: Request }) => {
     declined: rsvpCountRows.find((c) => c.status === "declined")?.count ?? 0,
   };
 
+  // Get attendee preview (first 5 accepted RSVPs for public display)
+  const attendeePreview = await db
+    .select({
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+    })
+    .from(rsvps)
+    .innerJoin(users, eq(rsvps.userId, users.id))
+    .where(and(eq(rsvps.eventId, eventId), eq(rsvps.status, "accepted")))
+    .orderBy(rsvps.createdAt)
+    .limit(5);
+
   // Get questions with answer counts
   const questions = await db
     .select({
@@ -210,6 +222,7 @@ export const GET = async ({ request }: { request: Request }) => {
     event,
     organizers,
     rsvpCounts,
+    attendeePreview,
     questionCount,
     questions,
     tiers,


### PR DESCRIPTION
## Summary
- Show an avatar stack and names of the first attendees in the event detail page's location section, visible to all visitors
- Fetch up to 5 accepted RSVPs from the existing event detail API endpoint (no new endpoint needed)
- Displays overlapping avatar circles with a "+N more" indicator and a text line like "Alice, Bob, Charlie and 9 others"

<img width="500" height="566" alt="스크린샷 2026-03-15 13 04 45" src="https://github.com/user-attachments/assets/c18656e4-75b0-4379-bfd8-b2d864a5f7c8" />

## Test plan
- [x] Visit a public event page with RSVPs — avatar stack and names appear below location
- [x] Event with 0 attendees — no attendee preview shown
- [x] Event with 1-3 attendees — avatars + names listed, no "and N others"
- [x] Event with >5 attendees — 5 avatars + "+N more", names + "and N others"