### PR TITLE
Add organizers to ICS calendar feeds

### DIFF
--- a/src/routes/events/-ics.ts
+++ b/src/routes/events/-ics.ts
@@ -2,6 +2,7 @@ import { and, eq, gte, isNull, isNotNull, asc, type SQL } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { actors, events, places } from "~/server/db/schema";
 import { buildIcsResponse } from "~/server/events/ics";
+import { attachOrganizers } from "~/server/events/ics-organizers";
 
 const ICS_LIMIT = 100;
 
@@ -46,5 +47,6 @@ export const GET = async ({
     .orderBy(asc(events.startsAt))
     .limit(ICS_LIMIT);
 
-  return buildIcsResponse(rows, { calendarName });
+  const icsEvents = await attachOrganizers(rows);
+  return buildIcsResponse(icsEvents, { calendarName });
 };

--- a/src/routes/events/-personal-ics.ts
+++ b/src/routes/events/-personal-ics.ts
@@ -2,6 +2,7 @@ import { aliasedTable, and, eq, isNull, asc } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { users, rsvps, events, actors, places, eventFavourites, groupMembers } from "~/server/db/schema";
 import { buildIcsResponse, type IcsEvent } from "~/server/events/ics";
+import { attachOrganizers } from "~/server/events/ics-organizers";
 
 const PERSONAL_ICS_LIMIT = 500;
 
@@ -119,7 +120,8 @@ export const GET = async ({
     (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
   );
 
-  return buildIcsResponse(merged, {
+  const withOrganizers = await attachOrganizers(merged);
+  return buildIcsResponse(withOrganizers, {
     calendarName: "My Moim Events",
     cacheControl: "private, max-age=900",
   });

--- a/src/server/events/ics-organizers.ts
+++ b/src/server/events/ics-organizers.ts
@@ -1,0 +1,40 @@
+import { eq, inArray } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { actors, eventOrganizers } from "~/server/db/schema";
+import type { IcsEventOrganizer } from "~/server/events/ics";
+
+/**
+ * Given a list of event rows (without organizers), batch-fetch organizers from
+ * the eventOrganizers table and attach them to each event.
+ */
+export async function attachOrganizers<
+  T extends { id: string },
+>(rows: T[]): Promise<(T & { organizers: IcsEventOrganizer[] })[]> {
+  if (rows.length === 0) return [];
+
+  const eventIds = rows.map((r) => r.id);
+
+  const orgRows = await db
+    .select({
+      eventId: eventOrganizers.eventId,
+      actorName: actors.name,
+      externalName: eventOrganizers.name,
+    })
+    .from(eventOrganizers)
+    .leftJoin(actors, eq(eventOrganizers.actorId, actors.id))
+    .where(inArray(eventOrganizers.eventId, eventIds));
+
+  const orgMap = new Map<string, IcsEventOrganizer[]>();
+  for (const row of orgRows) {
+    const name = row.externalName ?? row.actorName;
+    if (!name) continue;
+    const list = orgMap.get(row.eventId) ?? [];
+    list.push({ name });
+    orgMap.set(row.eventId, list);
+  }
+
+  return rows.map((r) => ({
+    ...r,
+    organizers: orgMap.get(r.id) ?? [],
+  }));
+}

--- a/src/server/events/ics.ts
+++ b/src/server/events/ics.ts
@@ -1,5 +1,9 @@
 import { env } from "~/server/env";
 
+export interface IcsEventOrganizer {
+  name: string;
+}
+
 export interface IcsEvent {
   id: string;
   title: string;
@@ -13,6 +17,7 @@ export interface IcsEvent {
   placeAddress: string | null;
   groupName: string | null;
   groupHandle: string | null;
+  organizers?: IcsEventOrganizer[];
   status?: "CONFIRMED" | "TENTATIVE";
 }
 
@@ -52,7 +57,8 @@ export function buildVevent(event: IcsEvent, baseUrl: string): string {
   if (location) {
     lines.push(`LOCATION:${escapeIcs(location)}`);
   }
-  const organizer = event.groupName ?? (event.groupHandle ? `@${event.groupHandle}` : "");
+  const organizerNames = (event.organizers ?? []).map((o) => o.name);
+  const groupLabel = event.groupName ?? (event.groupHandle ? `@${event.groupHandle}` : "");
   const eventUrl = event.externalUrl || `${baseUrl}/events/${event.id}`;
   if (event.status) {
     lines.push(`STATUS:${event.status}`);
@@ -61,15 +67,23 @@ export function buildVevent(event: IcsEvent, baseUrl: string): string {
   if (event.status === "TENTATIVE") {
     descParts.push("[Favourited] This event is bookmarked, not officially confirmed.");
   }
-  if (organizer) descParts.push(`Hosted by: ${organizer}`);
+  if (organizerNames.length > 0) {
+    descParts.push(`Organizers: ${organizerNames.join(", ")}`);
+  }
+  if (groupLabel) descParts.push(`Hosted by: ${groupLabel}`);
   descParts.push(`Link: ${eventUrl}`);
   if (event.description) {
     const plain = event.description.replace(/<[^>]*>/g, "");
     descParts.push("", plain);
   }
   lines.push(`DESCRIPTION:${escapeIcs(descParts.join("\n"))}`);
-  if (organizer) {
-    lines.push(`ORGANIZER;CN=${escapeIcs(organizer)}:mailto:noreply@${new URL(baseUrl).hostname}`);
+  const hostname = new URL(baseUrl).hostname;
+  if (organizerNames.length > 0) {
+    for (const name of organizerNames) {
+      lines.push(`ORGANIZER;CN=${escapeIcs(name)}:mailto:noreply@${hostname}`);
+    }
+  } else if (groupLabel) {
+    lines.push(`ORGANIZER;CN=${escapeIcs(groupLabel)}:mailto:noreply@${hostname}`);
   }
   lines.push(`URL:${eventUrl}`);
   lines.push("END:VEVENT");


### PR DESCRIPTION
## Summary
Includes event organizer names in ICS calendar feeds (both group/category and personal). Organizers are batch-fetched from the `eventOrganizers` table and rendered as `ORGANIZER` properties on each VEVENT, as well as listed in the `DESCRIPTION` field. When no organizers are present, falls back to the group name as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events exported as ICS calendar files now include organizer information, enhancing calendar integration with organizer details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->