### PR TITLE
Add ICS calendar subscribe link to group events page

### DIFF
--- a/src/routes/groups/$identifier/events.tsx
+++ b/src/routes/groups/$identifier/events.tsx
@@ -10,7 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { EventCalendar, type CalendarEvent } from "~/components/EventCalendar";
 import { UpcomingEventList } from "~/components/UpcomingEventList";
-import { Calendar, ChevronLeft, List } from "lucide-react";
+import { Calendar, CalendarPlus, ChevronLeft, List } from "lucide-react";
 
 const getGroupMeta = createServerFn({ method: "GET" })
   .inputValidator(zodValidator(z.object({ handle: z.string() })))
@@ -80,7 +80,14 @@ function GroupEventsPage() {
             <p className="text-sm text-muted-foreground">{groupName}</p>
           </div>
         </div>
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
+          <a
+            href={`/groups/@${handle}/events.ics`}
+            title="Subscribe to calendar"
+            className="inline-flex items-center justify-center size-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          >
+            <CalendarPlus className="size-4" />
+          </a>
           <Button
             variant={view === "calendar" ? "default" : "outline"}
             size="sm"


### PR DESCRIPTION
## Summary
- Add a CalendarPlus icon link to the group events page header that links to the group's ICS calendar feed (`/groups/@{handle}/events.ics`)
- Allows users to easily discover and subscribe to a group's event calendar directly from the events listing

## Test plan
- [x] Navigate to a group's events page and verify the calendar subscribe icon appears in the header
- [x] Click the icon and confirm it links to the correct `.ics` feed URL
- [x] Verify the icon styling matches the existing view toggle buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar subscription support for group events. Users can now easily subscribe to group event calendars directly from event pages. This enables seamless integration with preferred calendar applications, ensuring automatic event updates and reminders so users never miss important group activities and announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->