### PR TITLE
Fix My Groups card layout for mobile

### DIFF
--- a/src/routes/groups/my.tsx
+++ b/src/routes/groups/my.tsx
@@ -95,7 +95,7 @@ function MyGroupsPage() {
                 className="block"
               >
                 <CardContent className="py-2">
-                  <div className="flex items-center gap-4">
+                  <div className="flex gap-3">
                     <Avatar className="size-10 shrink-0">
                       {group.avatarUrl && <AvatarImage src={group.avatarUrl} alt={group.name ?? group.handle} />}
                       <AvatarFallback className="text-sm font-semibold bg-primary/10 text-primary">
@@ -112,21 +112,24 @@ function MyGroupsPage() {
                         </Badge>
                       </div>
                       <p className="text-xs text-muted-foreground">@{group.handle}</p>
-                    </div>
-                    <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
-                      {languageLabel(group.language) && (
-                        <span>{languageLabel(group.language)}</span>
-                      )}
-                      <span>{group.followersCount} follower{group.followersCount !== 1 ? "s" : ""}</span>
-                      <span>{group.membersCount} member{group.membersCount !== 1 ? "s" : ""}</span>
-                      <span>
-                        {group.upcomingEventsCount + group.pastEventsCount} event{group.upcomingEventsCount + group.pastEventsCount !== 1 ? "s" : ""}
-                        {group.upcomingEventsCount > 0 && (
-                          <span className="text-primary font-medium ml-1">
-                            ({group.upcomingEventsCount} upcoming)
-                          </span>
-                        )}
-                      </span>
+                      <div className="mt-1.5 flex flex-col gap-0.5 text-xs text-muted-foreground">
+                        <span>
+                          {group.followersCount} follower{group.followersCount !== 1 ? "s" : ""}
+                          {" · "}
+                          {group.membersCount} member{group.membersCount !== 1 ? "s" : ""}
+                          {languageLabel(group.language) && (
+                            <>{" · "}{languageLabel(group.language)}</>
+                          )}
+                        </span>
+                        <span>
+                          {group.upcomingEventsCount + group.pastEventsCount} event{group.upcomingEventsCount + group.pastEventsCount !== 1 ? "s" : ""}
+                          {group.upcomingEventsCount > 0 && (
+                            <span className="text-primary font-medium ml-1">
+                              ({group.upcomingEventsCount} upcoming)
+                            </span>
+                          )}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </CardContent>


### PR DESCRIPTION
## Summary
- Stack the group card into a multi-row layout so stats (followers, members, events) appear below the name/handle instead of overflowing off-screen on mobile
- Stats are aligned with the group name, indented past the avatar

## Test plan
- [ ] View `/groups/my` on a narrow mobile viewport and confirm stats are fully visible
- [ ] Verify desktop layout still looks reasonable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated group information layout: moved followers, members, language label, and event details to a stacked vertical block below the group name and avatar, replacing the previous horizontal layout.
  * Enhanced metadata presentation with improved spacing and inline separators for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->