### PR TITLE
Add Hackers' Pub GraphQL authentication provider

### DIFF
--- a/src/routes/auth/hackerspub/-graphql-callback-api.ts
+++ b/src/routes/auth/hackerspub/-graphql-callback-api.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { sessions, users, userFediverseAccounts } from "~/server/db/schema";
+import { toProxyHandle } from "~/server/fediverse/handles";
+import { verifyAndConsumeHackersPubSession } from "~/server/hackerspub-sessions";
+
+export const POST = async ({ request }: { request: Request }) => {
+  const body = (await request.json().catch(() => null)) as {
+    token?: string;
+    code?: string;
+    state?: string;
+  } | null;
+
+  if (!body?.token) {
+    return Response.json({ error: "token is required" }, { status: 400 });
+  }
+  if (!body?.code) {
+    return Response.json({ error: "code is required" }, { status: 400 });
+  }
+  if (!body?.state) {
+    return Response.json({ error: "state is required" }, { status: 400 });
+  }
+
+  const { token, code, state } = body;
+
+  // Verify session was created by this server
+  const session = verifyAndConsumeHackersPubSession(state);
+  if (!session) {
+    console.warn("[HackersPub Callback] Session verification failed", {
+      state,
+    });
+    return Response.json(
+      { error: "invalid_session", reason: "session_expired" },
+      { status: 401 },
+    );
+  }
+
+  const { instance, username } = session;
+
+  try {
+    // Complete the login challenge via GraphQL
+    const graphqlUrl = `https://${instance}/graphql`;
+
+    const challengeRes = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `
+          mutation CompleteLoginChallenge($token: UUID!, $code: String!) {
+            completeLoginChallenge(token: $token, code: $code) {
+              id
+              account {
+                username
+                handle
+                name
+                avatarUrl
+              }
+            }
+          }
+        `,
+        variables: { token, code },
+      }),
+    });
+
+    if (!challengeRes.ok) {
+      console.error(
+        "[HackersPub Callback] GraphQL request failed",
+        challengeRes.status,
+      );
+      return Response.json(
+        { error: "challenge_verification_failed" },
+        { status: 401 },
+      );
+    }
+
+    const challengeData = await challengeRes.json();
+    const hpSession = challengeData?.data?.completeLoginChallenge;
+
+    if (!hpSession) {
+      const gqlError =
+        challengeData?.errors?.[0]?.message ?? "challenge failed";
+      console.error("[HackersPub Callback] Challenge failed:", gqlError);
+      return Response.json(
+        { error: "challenge_failed", message: gqlError },
+        { status: 401 },
+      );
+    }
+
+    // Extract user info from the session response
+    const hpAccount = hpSession.account;
+    const hpUsername = hpAccount?.username ?? username;
+    const displayName = hpAccount?.name ?? hpUsername;
+    const avatarUrl = hpAccount?.avatarUrl ?? null;
+
+    // Build the fediverse handle
+    const handle = `${hpUsername}@${instance}`;
+    const proxyHandle = toProxyHandle(handle);
+
+    // Find or create user (same pattern as Mastodon/Misskey)
+    let user: typeof users.$inferSelect | undefined;
+
+    // Check userFediverseAccounts for existing link
+    const [linked] = await db
+      .select({ userId: userFediverseAccounts.userId })
+      .from(userFediverseAccounts)
+      .where(eq(userFediverseAccounts.fediverseHandle, handle))
+      .limit(1);
+
+    if (linked) {
+      const [found] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, linked.userId))
+        .limit(1);
+      user = found;
+    }
+
+    // Check legacy users.fediverseHandle
+    if (!user) {
+      const [legacyUser] = await db
+        .select()
+        .from(users)
+        .where(eq(users.fediverseHandle, handle))
+        .limit(1);
+
+      if (legacyUser) {
+        await db.transaction(async (tx) => {
+          await tx
+            .insert(userFediverseAccounts)
+            .values({
+              userId: legacyUser.id,
+              fediverseHandle: handle,
+              proxyHandle,
+              isPrimary: true,
+            })
+            .onConflictDoNothing();
+        });
+        user = legacyUser;
+      }
+    }
+
+    // Create new user
+    if (!user) {
+      await db.transaction(async (tx) => {
+        const [created] = await tx
+          .insert(users)
+          .values({
+            handle: proxyHandle,
+            fediverseHandle: handle,
+            displayName,
+            avatarUrl,
+            summary: null,
+          })
+          .returning();
+
+        await tx.insert(userFediverseAccounts).values({
+          userId: created.id,
+          fediverseHandle: handle,
+          proxyHandle,
+          isPrimary: true,
+        });
+
+        user = created;
+      });
+    }
+
+    if (!user) {
+      throw new Error("Failed to find or create user");
+    }
+
+    // Create Moim session
+    const sessionToken = randomUUID().replace(/-/g, "");
+    await db.insert(sessions).values({
+      userId: user.id,
+      token: sessionToken,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+
+    const headers = new Headers();
+    headers.set(
+      "Set-Cookie",
+      `session_token=${sessionToken}; HttpOnly; Secure; Path=/; Max-Age=${30 * 24 * 60 * 60}; SameSite=Lax`,
+    );
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        user: { id: user.id, handle: user.fediverseHandle ?? user.handle },
+      }),
+      { status: 200, headers },
+    );
+  } catch (error) {
+    console.error("[HackersPub Callback] Error:", error);
+    return Response.json({ error: "server_error" }, { status: 500 });
+  }
+};

--- a/src/routes/auth/hackerspub/-graphql-callback.ts
+++ b/src/routes/auth/hackerspub/-graphql-callback.ts
@@ -1,0 +1,63 @@
+export const GET = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+
+  if (!token || !code || !state) {
+    return new Response("Missing token, code, or state", { status: 400 });
+  }
+
+  const payload = JSON.stringify({ token, code, state })
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Hackers' Pub Auth</title>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body>
+      <p>Processing authentication...</p>
+      <script id="auth-payload" type="application/json">${payload}</script>
+      <script>
+        (async () => {
+          try {
+            const payloadNode = document.getElementById("auth-payload");
+            if (!payloadNode || !payloadNode.textContent) {
+              throw new Error("Missing auth payload");
+            }
+            const payload = JSON.parse(payloadNode.textContent);
+            const response = await fetch('/api/auth/hackerspub/graphql-callback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+              credentials: 'include',
+            });
+
+            const data = await response.json();
+
+            if (response.ok) {
+              window.location.href = '/';
+            } else {
+              window.location.href = '/?error=' + (data.error || 'auth_failed');
+            }
+          } catch (error) {
+            console.error('Error:', error);
+            window.location.href = '/?error=server_error';
+          }
+        })();
+      </script>
+    </body>
+    </html>
+  `;
+
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+};

--- a/src/routes/auth/hackerspub/-graphql-start.ts
+++ b/src/routes/auth/hackerspub/-graphql-start.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from "crypto";
+import { env } from "~/server/env";
+import {
+  createHackersPubSession,
+  validateInstanceHostname,
+} from "~/server/hackerspub-sessions";
+
+export const POST = async ({ request }: { request: Request }) => {
+  const body = (await request.json().catch(() => null)) as {
+    instance?: string;
+    username?: string;
+  } | null;
+
+  if (!body?.instance) {
+    return Response.json({ error: "instance is required" }, { status: 400 });
+  }
+  if (!body?.username) {
+    return Response.json({ error: "username is required" }, { status: 400 });
+  }
+
+  const instance = body.instance
+    .replace(/^https?:\/\//, "")
+    .replace(/\/$/, "");
+  const username = body.username.trim();
+
+  if (!validateInstanceHostname(instance)) {
+    return Response.json({ error: "invalid_instance" }, { status: 400 });
+  }
+
+  const state = randomUUID();
+
+  // Store session for callback verification
+  const ttlSecondsEnv = parseInt(
+    process.env.HACKERSPUB_SESSION_TTL_SECONDS ?? "600",
+    10,
+  );
+  const ttlSeconds =
+    isFinite(ttlSecondsEnv) && ttlSecondsEnv > 0 ? ttlSecondsEnv : 600; // 10 min default (email delivery can be slow)
+  createHackersPubSession(state, instance, username, ttlSeconds);
+
+  // Build verifyUrl template — HackersPub will substitute {token} and {code}
+  const callbackBase = `${env.baseUrl}/auth/hackerspub/callback`;
+  const verifyUrl = `${callbackBase}?token={token}&code={code}&state=${encodeURIComponent(state)}`;
+
+  // Call HackersPub GraphQL loginByUsername mutation
+  const graphqlUrl = `https://${instance}/graphql`;
+  try {
+    const res = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `
+          mutation LoginByUsername($username: String!, $locale: Locale!, $verifyUrl: URITemplate!) {
+            loginByUsername(username: $username, locale: $locale, verifyUrl: $verifyUrl) {
+              ... on LoginChallenge {
+                __typename
+                token
+              }
+              ... on AccountNotFoundError {
+                __typename
+                query
+              }
+            }
+          }
+        `,
+        variables: {
+          username,
+          locale: "en",
+          verifyUrl,
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      return Response.json(
+        { error: "graphql_request_failed" },
+        { status: 502 },
+      );
+    }
+
+    const data = await res.json();
+    const result = data?.data?.loginByUsername;
+
+    if (!result) {
+      const gqlError = data?.errors?.[0]?.message ?? "unknown GraphQL error";
+      return Response.json({ error: gqlError }, { status: 400 });
+    }
+
+    if (result.__typename === "AccountNotFoundError") {
+      return Response.json(
+        { error: "account_not_found", message: `Account not found: ${result.query}` },
+        { status: 404 },
+      );
+    }
+
+    // LoginChallenge returned — email has been sent
+    return Response.json({ ok: true });
+  } catch {
+    return Response.json({ error: "network_error" }, { status: 502 });
+  }
+};

--- a/src/routes/auth/signin.tsx
+++ b/src/routes/auth/signin.tsx
@@ -51,6 +51,12 @@ type AuthProviderDef = {
 
 const AUTH_PROVIDERS: AuthProviderDef[] = [
   {
+    id: "hackerspub",
+    name: "Hackers' Pub",
+    icon: "💻",
+    DialogForm: HackersPubDialogForm,
+  },
+  {
     id: "mastodon",
     name: "Mastodon",
     icon: "🐘",
@@ -292,6 +298,134 @@ function MiAuthDialogForm({ onClose: _onClose }: { onClose: () => void }) {
 
         <p className="text-xs text-muted-foreground flex items-center gap-1.5">
           <span>🔒</span> Read-only access — we never post on your behalf
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── HackersPub GraphQL Auth ────────────────────────────────────────────────
+
+function HackersPubDialogForm({ onClose: _onClose }: { onClose: () => void }) {
+  const [instance, setInstance] = useState("hackers.pub");
+  const [username, setUsername] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function submit() {
+    setError("");
+    const trimmedInstance = instance.trim();
+    const trimmedUsername = username.trim();
+    if (!trimmedInstance) {
+      setError("Please enter a Hackers' Pub instance");
+      return;
+    }
+    if (!trimmedUsername) {
+      setError("Please enter your username");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/hackerspub/graphql-start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ instance: trimmedInstance, username: trimmedUsername }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.message ?? data.error ?? "Failed to start login");
+        setLoading(false);
+        return;
+      }
+      setSent(true);
+      setLoading(false);
+    } catch {
+      setError("Network error");
+      setLoading(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="flex flex-col sm:flex-row gap-6">
+        <div className="flex flex-col items-center justify-center sm:w-40 sm:shrink-0 sm:border-r sm:pr-6">
+          <span className="text-5xl">💻</span>
+          <p className="mt-2 text-lg font-semibold">Hackers' Pub</p>
+        </div>
+        <div className="flex-1 space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Check your email!</p>
+            <p className="text-sm text-muted-foreground">
+              We sent a verification link to the email associated with your Hackers' Pub account
+              <strong> @{username.trim()}</strong>. Click the link to complete sign-in.
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => { setSent(false); setError(""); }}>
+            Try again
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-6">
+      <div className="flex flex-col items-center justify-center sm:w-40 sm:shrink-0 sm:border-r sm:pr-6">
+        <span className="text-5xl">💻</span>
+        <p className="mt-2 text-lg font-semibold">Hackers' Pub</p>
+        <p className="text-xs text-muted-foreground text-center mt-1">
+          Email verification
+        </p>
+      </div>
+
+      <div className="flex-1 space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="hp-instance">Instance</Label>
+            <Input
+              id="hp-instance"
+              type="text"
+              placeholder="hackerspub.dev"
+              value={instance}
+              onChange={(e) => setInstance(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="hp-username">Username</Label>
+            <Input
+              id="hp-username"
+              type="text"
+              placeholder="your_username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Sending..." : "Send verification email"}
+          </Button>
+        </form>
+
+        <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+          <span>🔒</span> We'll send a verification link to your email
         </p>
       </div>
     </div>

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -101,6 +101,10 @@ import { POST as mastodonOAuthStart } from "./routes/auth/mastodon/-oauth-start"
 import { GET as mastodonOAuthCallback } from "./routes/auth/mastodon/-oauth-callback"
 import { POST as mastodonOAuthCallbackApi } from "./routes/auth/mastodon/-oauth-callback-api"
 import { startOAuthCleanupInterval } from "./server/mastodon-oauth-sessions"
+import { POST as hackerspubGraphqlStart } from "./routes/auth/hackerspub/-graphql-start"
+import { GET as hackerspubGraphqlCallback } from "./routes/auth/hackerspub/-graphql-callback"
+import { POST as hackerspubGraphqlCallbackApi } from "./routes/auth/hackerspub/-graphql-callback-api"
+import { startHackersPubCleanupInterval } from "./server/hackerspub-sessions"
 import { startGdprCleanupInterval } from "./server/events/gdpr-cleanup"
 
 const startFetch = createStartHandler(defaultStreamHandler);
@@ -111,6 +115,7 @@ app.use(integrateFederation(federation, () => undefined));
 // Start the MiAuth session cleanup interval
 startCleanupInterval();
 startOAuthCleanupInterval();
+startHackersPubCleanupInterval();
 startGdprCleanupInterval();
 
 const apiRouter = createRouter();
@@ -212,6 +217,14 @@ apiRouter.post("/auth/mastodon/oauth-start", defineEventHandler(async (event) =>
 
 apiRouter.post("/auth/mastodon/oauth-callback", defineEventHandler(async (event) => {
   return mastodonOAuthCallbackApi({ request: toWebRequest(event) });
+}));
+
+apiRouter.post("/auth/hackerspub/graphql-start", defineEventHandler(async (event) => {
+  return hackerspubGraphqlStart({ request: toWebRequest(event) });
+}));
+
+apiRouter.post("/auth/hackerspub/graphql-callback", defineEventHandler(async (event) => {
+  return hackerspubGraphqlCallbackApi({ request: toWebRequest(event) });
 }));
 
 apiRouter.get("/session", defineEventHandler(async (event) => {
@@ -905,6 +918,11 @@ app.use("/auth/misskey/miauth-callback", defineEventHandler(async (event) => {
 // Mastodon OAuth callback (outside /api)
 app.use("/auth/mastodon/oauth-callback", defineEventHandler(async (event) => {
   return mastodonOAuthCallback({ request: toWebRequest(event) });
+}));
+
+// HackersPub GraphQL callback (outside /api)
+app.use("/auth/hackerspub/callback", defineEventHandler(async (event) => {
+  return hackerspubGraphqlCallback({ request: toWebRequest(event) });
 }));
 
 // Map image routes

--- a/src/server/hackerspub-sessions.ts
+++ b/src/server/hackerspub-sessions.ts
@@ -1,0 +1,72 @@
+/**
+ * In-memory store for HackersPub GraphQL auth sessions.
+ * Each session is created during the start phase and consumed during callback.
+ */
+
+import { validateInstanceHostname } from "./miauth-sessions";
+
+export { validateInstanceHostname };
+
+interface HackersPubSession {
+  state: string;
+  instance: string;
+  username: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const sessions = new Map<string, HackersPubSession>();
+
+let cleanupIntervalId: NodeJS.Timeout | null = null;
+
+export function createHackersPubSession(
+  state: string,
+  instance: string,
+  username: string,
+  ttlSeconds: number,
+): void {
+  const now = Date.now();
+  sessions.set(state, {
+    state,
+    instance,
+    username,
+    createdAt: now,
+    expiresAt: now + ttlSeconds * 1000,
+  });
+}
+
+export function verifyAndConsumeHackersPubSession(
+  state: string,
+): { instance: string; username: string } | null {
+  const session = sessions.get(state);
+  if (!session) return null;
+
+  // Always consume — prevents replay
+  sessions.delete(state);
+
+  // Check expiration
+  if (Date.now() > session.expiresAt) return null;
+
+  return { instance: session.instance, username: session.username };
+}
+
+function cleanupExpiredSessions(): void {
+  const now = Date.now();
+  for (const [key, session] of sessions) {
+    if (now > session.expiresAt) {
+      sessions.delete(key);
+    }
+  }
+}
+
+export function startHackersPubCleanupInterval(): void {
+  if (cleanupIntervalId) return;
+  cleanupIntervalId = setInterval(cleanupExpiredSessions, 60_000);
+}
+
+export function stopHackersPubCleanupInterval(): void {
+  if (cleanupIntervalId) {
+    clearInterval(cleanupIntervalId);
+    cleanupIntervalId = null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds Hackers' Pub as a fourth auth provider using its existing GraphQL API — zero changes needed to HackersPub's codebase. The flow leverages HackersPub's `loginByUsername` mutation which accepts a `verifyUrl` URI template, allowing Moim to receive the email verification callback directly.

Flow: user enters instance URL (default: hackers.pub) + username → Moim calls `loginByUsername` with `verifyUrl` pointing to Moim's callback → HackersPub sends verification email → user clicks link → Moim calls `completeLoginChallenge` → gets session + account info → creates/links Moim user.

## Test plan
- [x] Sign in page shows "Hackers' Pub" in "Or sign in with" section
- [x] Dialog collects instance URL (pre-filled with hackers.pub) + username
- [x] Submitting calls `/api/auth/hackerspub/graphql-start` and shows "Check your email"
- [x] Email link redirects to `/auth/hackerspub/callback` which completes auth
- [x] User is created with correct fediverse handle (`username@instance`)
- [x] Session cookie is set, user is logged in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HackersPub sign-in: enter your instance and username to start login.
  * Two-step dialog UI with a confirmation "check your email" view and retry option.
  * Automatic account resolution/creation so returning or new HackersPub users are signed in.
  * Sessions persist for 30 days; user-facing error messages are shown for failed logins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->