### PR TITLE
Add event notice system with federated delivery

### DIFF
--- a/drizzle/0047_broad_firestar.sql
+++ b/drizzle/0047_broad_firestar.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "event_notices" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"post_id" uuid NOT NULL,
+	"sent_by_user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "event_notices" ADD CONSTRAINT "event_notices_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "event_notices" ADD CONSTRAINT "event_notices_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "event_notices" ADD CONSTRAINT "event_notices_sent_by_user_id_users_id_fk" FOREIGN KEY ("sent_by_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0047_snapshot.json
+++ b/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,3102 @@
+{
+  "id": "19cdf880-1306-4fa5-9590-9712d76ffcb0",
+  "prevId": "394e09d6-fb9e-48c7-a6cc-0269b6fd104e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_url": {
+          "name": "activity_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_post_id": {
+          "name": "reply_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_actor_id_actors_id_fk": {
+          "name": "activity_logs_actor_id_actors_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_post_id_posts_id_fk": {
+          "name": "activity_logs_post_id_posts_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_event_id_events_id_fk": {
+          "name": "activity_logs_event_id_events_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_reply_post_id_posts_id_fk": {
+          "name": "activity_logs_reply_post_id_posts_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "reply_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_logs_actor_id_post_id_type_emoji_unique": {
+          "name": "activity_logs_actor_id_post_id_type_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "post_id",
+            "type",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actors": {
+      "name": "actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Person'"
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_url": {
+          "name": "outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_url": {
+          "name": "following_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "manually_approves_followers": {
+          "name": "manually_approves_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actors_user_id_users_id_fk": {
+          "name": "actors_user_id_users_id_fk",
+          "tableFrom": "actors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actors_handle_unique": {
+          "name": "actors_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h3_index": {
+          "name": "h3_index",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hop_count": {
+          "name": "hop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impression_count": {
+          "name": "impression_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkins": {
+      "name": "checkins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkins_user_id_users_id_fk": {
+          "name": "checkins_user_id_users_id_fk",
+          "tableFrom": "checkins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "checkins_place_id_places_id_fk": {
+          "name": "checkins_place_id_places_id_fk",
+          "tableFrom": "checkins",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alpha3": {
+          "name": "alpha3",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bbox": {
+          "name": "bbox",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_categories": {
+      "name": "event_categories",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favourites": {
+      "name": "event_favourites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favourites_user_id_users_id_fk": {
+          "name": "event_favourites_user_id_users_id_fk",
+          "tableFrom": "event_favourites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_favourites_event_id_events_id_fk": {
+          "name": "event_favourites_event_id_events_id_fk",
+          "tableFrom": "event_favourites",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_favourites_user_id_event_id_unique": {
+          "name": "event_favourites_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_notices": {
+      "name": "event_notices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_notices_event_id_events_id_fk": {
+          "name": "event_notices_event_id_events_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_notices_post_id_posts_id_fk": {
+          "name": "event_notices_post_id_posts_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_notices_sent_by_user_id_users_id_fk": {
+          "name": "event_notices_sent_by_user_id_users_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_organizers": {
+      "name": "event_organizers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_organizers_event_id_events_id_fk": {
+          "name": "event_organizers_event_id_events_id_fk",
+          "tableFrom": "event_organizers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizers_actor_id_actors_id_fk": {
+          "name": "event_organizers_actor_id_actors_id_fk",
+          "tableFrom": "event_organizers",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_questions": {
+      "name": "event_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_questions_event_id_events_id_fk": {
+          "name": "event_questions_event_id_events_id_fk",
+          "tableFrom": "event_questions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tags": {
+      "name": "event_tags",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_tags_tag_id_tags_id_fk": {
+          "name": "event_tags_tag_id_tags_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_tags_event_id_tag_id_pk": {
+          "name": "event_tags_event_id_tag_id_pk",
+          "columns": [
+            "event_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tiers": {
+      "name": "event_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tiers_event_id_events_id_fk": {
+          "name": "event_tiers_event_id_events_id_fk",
+          "tableFrom": "event_tiers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue_detail": {
+          "name": "venue_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_image_url": {
+          "name": "header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allow_anonymous_rsvp": {
+          "name": "allow_anonymous_rsvp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "anonymous_contact_fields": {
+          "name": "anonymous_contact_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_organizer_id_users_id_fk": {
+          "name": "events_organizer_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_group_actor_id_actors_id_fk": {
+          "name": "events_group_actor_id_actors_id_fk",
+          "tableFrom": "events",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_category_id_event_categories_slug_fk": {
+          "name": "events_category_id_event_categories_slug_fk",
+          "tableFrom": "events",
+          "tableTo": "event_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_place_id_places_id_fk": {
+          "name": "events_place_id_places_id_fk",
+          "tableFrom": "events",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_actors_id_fk": {
+          "name": "follows_follower_id_actors_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_actors_id_fk": {
+          "name": "follows_following_id_actors_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_actor_id": {
+          "name": "member_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_group_actor_id_actors_id_fk": {
+          "name": "group_members_group_actor_id_actors_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_member_actor_id_actors_id_fk": {
+          "name": "group_members_member_actor_id_actors_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "member_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_places": {
+      "name": "group_places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by_user_id": {
+          "name": "assigned_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_places_group_actor_id_actors_id_fk": {
+          "name": "group_places_group_actor_id_actors_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_places_place_id_places_id_fk": {
+          "name": "group_places_place_id_places_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_places_assigned_by_user_id_users_id_fk": {
+          "name": "group_places_assigned_by_user_id_users_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_places_group_actor_id_place_id_unique": {
+          "name": "group_places_group_actor_id_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_actor_id",
+            "place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keypairs": {
+      "name": "keypairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keypairs_actor_id_actors_id_fk": {
+          "name": "keypairs_actor_id_actors_id_fk",
+          "tableFrom": "keypairs",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenges": {
+      "name": "otp_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expected_emojis": {
+          "name": "expected_emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenges_question_id_unique": {
+          "name": "otp_challenges_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_votes": {
+      "name": "otp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_actor_url": {
+          "name": "voter_actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "otp_votes_challenge_id_otp_challenges_id_fk": {
+          "name": "otp_votes_challenge_id_otp_challenges_id_fk",
+          "tableFrom": "otp_votes",
+          "tableTo": "otp_challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_votes_challenge_id_emoji_unique": {
+          "name": "otp_votes_challenge_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_audit_log": {
+      "name": "place_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_audit_log_place_id_places_id_fk": {
+          "name": "place_audit_log_place_id_places_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_audit_log_group_actor_id_actors_id_fk": {
+          "name": "place_audit_log_group_actor_id_actors_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_audit_log_user_id_users_id_fk": {
+          "name": "place_audit_log_user_id_users_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_categories": {
+      "name": "place_categories",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_categories_parent_slug_place_categories_slug_fk": {
+          "name": "place_categories_parent_slug_place_categories_slug_fk",
+          "tableFrom": "place_categories",
+          "tableTo": "place_categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_tags": {
+      "name": "place_tags",
+      "schema": "",
+      "columns": {
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_tags_place_id_places_id_fk": {
+          "name": "place_tags_place_id_places_id_fk",
+          "tableFrom": "place_tags",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_tags_tag_id_tags_id_fk": {
+          "name": "place_tags_tag_id_tags_id_fk",
+          "tableFrom": "place_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "place_tags_place_id_tag_id_pk": {
+          "name": "place_tags_place_id_tag_id_pk",
+          "columns": [
+            "place_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "places_category_id_place_categories_slug_fk": {
+          "name": "places_category_id_place_categories_slug_fk",
+          "tableFrom": "places",
+          "tableTo": "place_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "places_created_by_id_users_id_fk": {
+          "name": "places_created_by_id_users_id_fk",
+          "tableFrom": "places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_options_poll_id_polls_id_fk": {
+          "name": "poll_options_poll_id_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_actor_url": {
+          "name": "voter_actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_instance": {
+          "name": "source_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_votes_poll_id_polls_id_fk": {
+          "name": "poll_votes_poll_id_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_votes_option_id_poll_options_id_fk": {
+          "name": "poll_votes_option_id_poll_options_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_votes_poll_id_option_id_voter_actor_url_unique": {
+          "name": "poll_votes_poll_id_option_id_voter_actor_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "option_id",
+            "voter_actor_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_group_actor_id_actors_id_fk": {
+          "name": "polls_group_actor_id_actors_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_question_id_unique": {
+          "name": "polls_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_uri": {
+          "name": "ap_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to_post_id": {
+          "name": "in_reply_to_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_root_id": {
+          "name": "thread_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_status": {
+          "name": "thread_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_replied_at": {
+          "name": "last_replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_actor_id_actors_id_fk": {
+          "name": "posts_actor_id_actors_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_event_id_events_id_fk": {
+          "name": "posts_event_id_events_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_in_reply_to_post_id_posts_id_fk": {
+          "name": "posts_in_reply_to_post_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "in_reply_to_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_thread_root_id_posts_id_fk": {
+          "name": "posts_thread_root_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "thread_root_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvp_answers": {
+      "name": "rsvp_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rsvp_id": {
+          "name": "rsvp_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvp_answers_rsvp_id_rsvps_id_fk": {
+          "name": "rsvp_answers_rsvp_id_rsvps_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "rsvps",
+          "columnsFrom": [
+            "rsvp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_user_id_users_id_fk": {
+          "name": "rsvp_answers_user_id_users_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_event_id_events_id_fk": {
+          "name": "rsvp_answers_event_id_events_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_question_id_event_questions_id_fk": {
+          "name": "rsvp_answers_question_id_event_questions_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "event_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsvp_answers_rsvp_id_question_id_unique": {
+          "name": "rsvp_answers_rsvp_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rsvp_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvps": {
+      "name": "rsvps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_user_id_users_id_fk": {
+          "name": "rsvps_user_id_users_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvps_event_id_events_id_fk": {
+          "name": "rsvps_event_id_events_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvps_tier_id_event_tiers_id_fk": {
+          "name": "rsvps_tier_id_event_tiers_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "event_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fediverse_accounts": {
+      "name": "user_fediverse_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fediverse_handle": {
+          "name": "fediverse_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_handle": {
+          "name": "proxy_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_fediverse_accounts_user_id_users_id_fk": {
+          "name": "user_fediverse_accounts_user_id_users_id_fk",
+          "tableFrom": "user_fediverse_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_fediverse_accounts_fediverse_handle_unique": {
+          "name": "user_fediverse_accounts_fediverse_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fediverse_handle"
+          ]
+        },
+        "user_fediverse_accounts_proxy_handle_unique": {
+          "name": "user_fediverse_accounts_proxy_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proxy_handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fediverse_handle": {
+          "name": "fediverse_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_source_hash": {
+          "name": "avatar_source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1775123144336,
       "tag": "0046_small_blindfold",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1775616861332,
+      "tag": "0047_broad_firestar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/i18n/locales/en/b2c.po
+++ b/src/i18n/locales/en/b2c.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:197
+msgid "Toggle menu"
+msgstr "Toggle menu"
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:90
 msgid "just now"
 msgstr "just now"
@@ -34,38 +39,33 @@ msgid "{days}d ago"
 msgstr "{days}d ago"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:183
-msgid "Toggle menu"
-msgstr "Toggle menu"
-
-#. js-lingui-explicit-id
 #: src/routes/events/index.tsx:144
 msgid "All countries"
 msgstr "All countries"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:319
+#: src/routes/events/$eventId/index.tsx:337
 msgid "{attendeeCount} attending ({anonymousCount} anonymous)"
 msgstr "{attendeeCount} attending ({anonymousCount} anonymous)"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:320
+#: src/routes/events/$eventId/index.tsx:338
 msgid "{attendeeCount} attending"
 msgstr "{attendeeCount} attending"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:352
-#: src/routes/events/$eventId/index.tsx:482
+#: src/routes/events/$eventId/index.tsx:370
+#: src/routes/events/$eventId/index.tsx:500
 msgid "Waitlisted (#{position})"
 msgstr "Waitlisted (#{position})"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:647
+#: src/routes/events/$eventId/index.tsx:665
 msgid "{names} and {count} others"
 msgstr "{names} and {count} others"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:821
+#: src/routes/events/$eventId/index.tsx:844
 msgid "About"
 msgstr "About"
 
@@ -75,8 +75,8 @@ msgid "AD"
 msgstr "AD"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:223
-#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:237
+#: src/routes/__root.tsx:274
 msgid "Admin Panel"
 msgstr "Admin Panel"
 
@@ -91,20 +91,20 @@ msgid "at"
 msgstr "at"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:480
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:498
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Attending"
 msgstr "Attending"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmark"
 msgstr "Bookmark"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmarked"
 msgstr "Bookmarked"
 
@@ -119,8 +119,8 @@ msgid "Browse Events"
 msgstr "Browse Events"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:379
-#: src/routes/events/$eventId/index.tsx:509
+#: src/routes/events/$eventId/index.tsx:397
+#: src/routes/events/$eventId/index.tsx:527
 msgid "Change RSVP"
 msgstr "Change RSVP"
 
@@ -130,9 +130,9 @@ msgid "Check In"
 msgstr "Check In"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:176
-#: src/routes/__root.tsx:246
-#: src/routes/__root.tsx:295
+#: src/routes/__root.tsx:190
+#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:325
 msgid "Check-ins"
 msgstr "Check-ins"
 
@@ -142,15 +142,15 @@ msgid "Create a group to start hosting events."
 msgstr "Create a group to start hosting events."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:217
-#: src/routes/__root.tsx:256
+#: src/routes/__root.tsx:231
+#: src/routes/__root.tsx:270
 #: src/routes/events/index.tsx:113
 msgid "Create Event"
 msgstr "Create Event"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:214
-#: src/routes/__root.tsx:255
+#: src/routes/__root.tsx:228
+#: src/routes/__root.tsx:269
 msgid "Create Group"
 msgstr "Create Group"
 
@@ -160,8 +160,8 @@ msgid "Create, discover, and RSVP to events hosted by groups across the fedivers
 msgstr "Create, discover, and RSVP to events hosted by groups across the fediverse."
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:707
-#: src/routes/events/$eventId/index.tsx:768
+#: src/routes/events/$eventId/index.tsx:725
+#: src/routes/events/$eventId/index.tsx:786
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -176,25 +176,25 @@ msgid "Discover upcoming events from groups across the fediverse."
 msgstr "Discover upcoming events from groups across the fediverse."
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:918
+#: src/routes/events/$eventId/index.tsx:941
 msgid "Discussion"
 msgstr "Discussion"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:697
-#: src/routes/events/$eventId/index.tsx:758
+#: src/routes/events/$eventId/index.tsx:715
+#: src/routes/events/$eventId/index.tsx:776
 msgid "Edit Event"
 msgstr "Edit Event"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:399
+#: src/routes/events/$eventId/index.tsx:417
 msgid "Event not found"
 msgstr "Event not found"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:175
-#: src/routes/__root.tsx:245
-#: src/routes/__root.tsx:294
+#: src/routes/__root.tsx:189
+#: src/routes/__root.tsx:259
+#: src/routes/__root.tsx:324
 #: src/routes/events/index.tsx:106
 #: src/routes/index.tsx:223
 msgid "Events"
@@ -206,7 +206,7 @@ msgid "Federated"
 msgstr "Federated"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:291
+#: src/routes/__root.tsx:310
 msgid "Federated events & check-ins"
 msgstr "Federated events & check-ins"
 
@@ -222,14 +222,14 @@ msgid "Go to {0} feed page"
 msgstr "Go to {0} feed page"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:350
+#: src/routes/events/$eventId/index.tsx:368
 msgid "Going"
 msgstr "Going"
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.groupName ?? `@${event.groupHandle}`
-#: src/routes/events/$eventId/index.tsx:677
-#: src/routes/events/$eventId/index.tsx:738
+#: src/routes/events/$eventId/index.tsx:695
+#: src/routes/events/$eventId/index.tsx:756
 msgid "Hosted by <0>{0}</0>"
 msgstr "Hosted by <0>{0}</0>"
 
@@ -241,16 +241,21 @@ msgstr "Hosted by <0>{hostLabel}</0>"
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.organizerHandle
-#: src/routes/events/$eventId/index.tsx:682
-#: src/routes/events/$eventId/index.tsx:684
-#: src/routes/events/$eventId/index.tsx:743
-#: src/routes/events/$eventId/index.tsx:745
+#: src/routes/events/$eventId/index.tsx:700
+#: src/routes/events/$eventId/index.tsx:702
+#: src/routes/events/$eventId/index.tsx:761
+#: src/routes/events/$eventId/index.tsx:763
 msgid "Hosted by <0>@{0}</0>"
 msgstr "Hosted by <0>@{0}</0>"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:395
-#: src/routes/events/$eventId/index.tsx:1000
+#: src/routes/__root.tsx:331
+msgid "footer.legal"
+msgstr "Legal"
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:413
+#: src/routes/events/$eventId/index.tsx:1023
 #: src/routes/events/index.tsx:197
 msgid "Loading..."
 msgstr "Loading..."
@@ -261,19 +266,19 @@ msgid "Moim is a federated events and places service — like connpass meets fou
 msgstr "Moim is a federated events and places service — like connpass meets foursquare, powered by ActivityPub."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:207
-#: src/routes/__root.tsx:252
+#: src/routes/__root.tsx:221
+#: src/routes/__root.tsx:266
 msgid "My Calendar"
 msgstr "My Calendar"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:204
-#: src/routes/__root.tsx:251
+#: src/routes/__root.tsx:218
+#: src/routes/__root.tsx:265
 msgid "My Groups"
 msgstr "My Groups"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:928
+#: src/routes/events/$eventId/index.tsx:951
 msgid "No discussions yet."
 msgstr "No discussions yet."
 
@@ -288,18 +293,23 @@ msgid "No upcoming events"
 msgstr "No upcoming events"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:483
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:501
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Not attending"
 msgstr "Not attending"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:353
+#: src/routes/events/$eventId/index.tsx:371
 msgid "Not going"
 msgstr "Not going"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:836
+#: src/routes/events/$eventId/index.tsx:1282
+msgid "Notices"
+msgstr "Notices"
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:859
 msgid "Organizers"
 msgstr "Organizers"
 
@@ -319,40 +329,65 @@ msgid "Places"
 msgstr "Places"
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:334
+msgid "Privacy Policy"
+msgstr "Privacy Policy"
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:173
 msgid "Recent Check-ins"
 msgstr "Recent Check-ins"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:370
-#: src/routes/events/$eventId/index.tsx:383
-#: src/routes/events/$eventId/index.tsx:500
-#: src/routes/events/$eventId/index.tsx:513
+#: src/routes/__root.tsx:335
+msgid "Refund Policy"
+msgstr "Refund Policy"
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:388
+#: src/routes/events/$eventId/index.tsx:401
+#: src/routes/events/$eventId/index.tsx:518
+#: src/routes/events/$eventId/index.tsx:531
 msgid "Register"
 msgstr "Register"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:329
-#: src/routes/events/$eventId/index.tsx:460
+#: src/routes/events/$eventId/index.tsx:347
+#: src/routes/events/$eventId/index.tsx:478
 msgid "Register externally"
 msgstr "Register externally"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:210
-#: src/routes/__root.tsx:253
+#: src/routes/__root.tsx:322
+msgid "footer.service"
+msgstr "Service"
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:224
+#: src/routes/__root.tsx:267
 msgid "Settings"
 msgstr "Settings"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:235
-#: src/routes/__root.tsx:270
+#: src/routes/events/$eventId/index.tsx:1294
+msgid "notices.showAll"
+msgstr "Show all ({count})"
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:1292
+msgid "Show less"
+msgstr "Show less"
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:249
+#: src/routes/__root.tsx:284
 #: src/routes/index.tsx:689
 msgid "Sign in"
 msgstr "Sign in"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:374
-#: src/routes/events/$eventId/index.tsx:504
+#: src/routes/events/$eventId/index.tsx:392
+#: src/routes/events/$eventId/index.tsx:522
 msgid "Sign in to RSVP"
 msgstr "Sign in to RSVP"
 
@@ -362,13 +397,18 @@ msgid "Sign in with your fediverse account. Follow groups from Mastodon, Misskey
 msgstr "Sign in with your fediverse account. Follow groups from Mastodon, Misskey, and more."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:229
-#: src/routes/__root.tsx:264
+#: src/routes/__root.tsx:243
+#: src/routes/__root.tsx:278
 msgid "Sign out"
 msgstr "Sign out"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:545
+#: src/routes/__root.tsx:333
+msgid "Terms of Service"
+msgstr "Terms of Service"
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:563
 msgid "to {endDateStr} {endTimeStr}"
 msgstr "to {endDateStr} {endTimeStr}"
 
@@ -398,7 +438,7 @@ msgid "View Event"
 msgstr "View Event"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:366
-#: src/routes/events/$eventId/index.tsx:496
+#: src/routes/events/$eventId/index.tsx:384
+#: src/routes/events/$eventId/index.tsx:514
 msgid "View Registration"
 msgstr "View Registration"

--- a/src/i18n/locales/ja/b2c.po
+++ b/src/i18n/locales/ja/b2c.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:197
+msgid "Toggle menu"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:90
 msgid "just now"
 msgstr ""
@@ -34,38 +39,33 @@ msgid "{days}d ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:183
-msgid "Toggle menu"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/events/index.tsx:144
 msgid "All countries"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:319
+#: src/routes/events/$eventId/index.tsx:337
 msgid "{attendeeCount} attending ({anonymousCount} anonymous)"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:320
+#: src/routes/events/$eventId/index.tsx:338
 msgid "{attendeeCount} attending"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:352
-#: src/routes/events/$eventId/index.tsx:482
+#: src/routes/events/$eventId/index.tsx:370
+#: src/routes/events/$eventId/index.tsx:500
 msgid "Waitlisted (#{position})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:647
+#: src/routes/events/$eventId/index.tsx:665
 msgid "{names} and {count} others"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:821
+#: src/routes/events/$eventId/index.tsx:844
 msgid "About"
 msgstr ""
 
@@ -75,8 +75,8 @@ msgid "AD"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:223
-#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:237
+#: src/routes/__root.tsx:274
 msgid "Admin Panel"
 msgstr ""
 
@@ -91,20 +91,20 @@ msgid "at"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:480
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:498
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Attending"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmark"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmarked"
 msgstr ""
 
@@ -119,8 +119,8 @@ msgid "Browse Events"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:379
-#: src/routes/events/$eventId/index.tsx:509
+#: src/routes/events/$eventId/index.tsx:397
+#: src/routes/events/$eventId/index.tsx:527
 msgid "Change RSVP"
 msgstr ""
 
@@ -130,9 +130,9 @@ msgid "Check In"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:176
-#: src/routes/__root.tsx:246
-#: src/routes/__root.tsx:295
+#: src/routes/__root.tsx:190
+#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:325
 msgid "Check-ins"
 msgstr ""
 
@@ -142,15 +142,15 @@ msgid "Create a group to start hosting events."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:217
-#: src/routes/__root.tsx:256
+#: src/routes/__root.tsx:231
+#: src/routes/__root.tsx:270
 #: src/routes/events/index.tsx:113
 msgid "Create Event"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:214
-#: src/routes/__root.tsx:255
+#: src/routes/__root.tsx:228
+#: src/routes/__root.tsx:269
 msgid "Create Group"
 msgstr ""
 
@@ -160,8 +160,8 @@ msgid "Create, discover, and RSVP to events hosted by groups across the fedivers
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:707
-#: src/routes/events/$eventId/index.tsx:768
+#: src/routes/events/$eventId/index.tsx:725
+#: src/routes/events/$eventId/index.tsx:786
 msgid "Dashboard"
 msgstr ""
 
@@ -176,25 +176,25 @@ msgid "Discover upcoming events from groups across the fediverse."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:918
+#: src/routes/events/$eventId/index.tsx:941
 msgid "Discussion"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:697
-#: src/routes/events/$eventId/index.tsx:758
+#: src/routes/events/$eventId/index.tsx:715
+#: src/routes/events/$eventId/index.tsx:776
 msgid "Edit Event"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:399
+#: src/routes/events/$eventId/index.tsx:417
 msgid "Event not found"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:175
-#: src/routes/__root.tsx:245
-#: src/routes/__root.tsx:294
+#: src/routes/__root.tsx:189
+#: src/routes/__root.tsx:259
+#: src/routes/__root.tsx:324
 #: src/routes/events/index.tsx:106
 #: src/routes/index.tsx:223
 msgid "Events"
@@ -206,7 +206,7 @@ msgid "Federated"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:291
+#: src/routes/__root.tsx:310
 msgid "Federated events & check-ins"
 msgstr ""
 
@@ -222,14 +222,14 @@ msgid "Go to {0} feed page"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:350
+#: src/routes/events/$eventId/index.tsx:368
 msgid "Going"
 msgstr ""
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.groupName ?? `@${event.groupHandle}`
-#: src/routes/events/$eventId/index.tsx:677
-#: src/routes/events/$eventId/index.tsx:738
+#: src/routes/events/$eventId/index.tsx:695
+#: src/routes/events/$eventId/index.tsx:756
 msgid "Hosted by <0>{0}</0>"
 msgstr ""
 
@@ -241,16 +241,21 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.organizerHandle
-#: src/routes/events/$eventId/index.tsx:682
-#: src/routes/events/$eventId/index.tsx:684
-#: src/routes/events/$eventId/index.tsx:743
-#: src/routes/events/$eventId/index.tsx:745
+#: src/routes/events/$eventId/index.tsx:700
+#: src/routes/events/$eventId/index.tsx:702
+#: src/routes/events/$eventId/index.tsx:761
+#: src/routes/events/$eventId/index.tsx:763
 msgid "Hosted by <0>@{0}</0>"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:395
-#: src/routes/events/$eventId/index.tsx:1000
+#: src/routes/__root.tsx:331
+msgid "footer.legal"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:413
+#: src/routes/events/$eventId/index.tsx:1023
 #: src/routes/events/index.tsx:197
 msgid "Loading..."
 msgstr ""
@@ -261,19 +266,19 @@ msgid "Moim is a federated events and places service — like connpass meets fou
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:207
-#: src/routes/__root.tsx:252
+#: src/routes/__root.tsx:221
+#: src/routes/__root.tsx:266
 msgid "My Calendar"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:204
-#: src/routes/__root.tsx:251
+#: src/routes/__root.tsx:218
+#: src/routes/__root.tsx:265
 msgid "My Groups"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:928
+#: src/routes/events/$eventId/index.tsx:951
 msgid "No discussions yet."
 msgstr ""
 
@@ -288,18 +293,23 @@ msgid "No upcoming events"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:483
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:501
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Not attending"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:353
+#: src/routes/events/$eventId/index.tsx:371
 msgid "Not going"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:836
+#: src/routes/events/$eventId/index.tsx:1282
+msgid "Notices"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:859
 msgid "Organizers"
 msgstr ""
 
@@ -319,40 +329,65 @@ msgid "Places"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:334
+msgid "Privacy Policy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:173
 msgid "Recent Check-ins"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:370
-#: src/routes/events/$eventId/index.tsx:383
-#: src/routes/events/$eventId/index.tsx:500
-#: src/routes/events/$eventId/index.tsx:513
+#: src/routes/__root.tsx:335
+msgid "Refund Policy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:388
+#: src/routes/events/$eventId/index.tsx:401
+#: src/routes/events/$eventId/index.tsx:518
+#: src/routes/events/$eventId/index.tsx:531
 msgid "Register"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:329
-#: src/routes/events/$eventId/index.tsx:460
+#: src/routes/events/$eventId/index.tsx:347
+#: src/routes/events/$eventId/index.tsx:478
 msgid "Register externally"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:210
-#: src/routes/__root.tsx:253
+#: src/routes/__root.tsx:322
+msgid "footer.service"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:224
+#: src/routes/__root.tsx:267
 msgid "Settings"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:235
-#: src/routes/__root.tsx:270
+#: src/routes/events/$eventId/index.tsx:1294
+msgid "notices.showAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:1292
+msgid "Show less"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:249
+#: src/routes/__root.tsx:284
 #: src/routes/index.tsx:689
 msgid "Sign in"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:374
-#: src/routes/events/$eventId/index.tsx:504
+#: src/routes/events/$eventId/index.tsx:392
+#: src/routes/events/$eventId/index.tsx:522
 msgid "Sign in to RSVP"
 msgstr ""
 
@@ -362,13 +397,18 @@ msgid "Sign in with your fediverse account. Follow groups from Mastodon, Misskey
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:229
-#: src/routes/__root.tsx:264
+#: src/routes/__root.tsx:243
+#: src/routes/__root.tsx:278
 msgid "Sign out"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:545
+#: src/routes/__root.tsx:333
+msgid "Terms of Service"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:563
 msgid "to {endDateStr} {endTimeStr}"
 msgstr ""
 
@@ -398,7 +438,7 @@ msgid "View Event"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:366
-#: src/routes/events/$eventId/index.tsx:496
+#: src/routes/events/$eventId/index.tsx:384
+#: src/routes/events/$eventId/index.tsx:514
 msgid "View Registration"
 msgstr ""

--- a/src/i18n/locales/ko/b2c.po
+++ b/src/i18n/locales/ko/b2c.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:197
+msgid "Toggle menu"
+msgstr "메뉴 열기/닫기"
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:90
 msgid "just now"
 msgstr "방금"
@@ -34,38 +39,33 @@ msgid "{days}d ago"
 msgstr "{days}일 전"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:183
-msgid "Toggle menu"
-msgstr "메뉴 열기/닫기"
-
-#. js-lingui-explicit-id
 #: src/routes/events/index.tsx:144
 msgid "All countries"
 msgstr "모든 국가"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:319
+#: src/routes/events/$eventId/index.tsx:337
 msgid "{attendeeCount} attending ({anonymousCount} anonymous)"
 msgstr "{attendeeCount}명 참석 (익명 {anonymousCount}명)"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:320
+#: src/routes/events/$eventId/index.tsx:338
 msgid "{attendeeCount} attending"
 msgstr "{attendeeCount}명 참석"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:352
-#: src/routes/events/$eventId/index.tsx:482
+#: src/routes/events/$eventId/index.tsx:370
+#: src/routes/events/$eventId/index.tsx:500
 msgid "Waitlisted (#{position})"
 msgstr "대기 중 (#{position})"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:647
+#: src/routes/events/$eventId/index.tsx:665
 msgid "{names} and {count} others"
 msgstr "{names} 외 {count}명"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:821
+#: src/routes/events/$eventId/index.tsx:844
 msgid "About"
 msgstr "소개"
 
@@ -75,8 +75,8 @@ msgid "AD"
 msgstr "광고"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:223
-#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:237
+#: src/routes/__root.tsx:274
 msgid "Admin Panel"
 msgstr "관리자 패널"
 
@@ -91,20 +91,20 @@ msgid "at"
 msgstr "에서"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:480
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:498
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Attending"
 msgstr "참석"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmark"
 msgstr "북마크"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:812
-#: src/routes/events/$eventId/index.tsx:1153
+#: src/routes/events/$eventId/index.tsx:830
+#: src/routes/events/$eventId/index.tsx:1176
 msgid "Bookmarked"
 msgstr "북마크됨"
 
@@ -119,8 +119,8 @@ msgid "Browse Events"
 msgstr "이벤트 둘러보기"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:379
-#: src/routes/events/$eventId/index.tsx:509
+#: src/routes/events/$eventId/index.tsx:397
+#: src/routes/events/$eventId/index.tsx:527
 msgid "Change RSVP"
 msgstr "참석 변경"
 
@@ -130,9 +130,9 @@ msgid "Check In"
 msgstr "체크인"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:176
-#: src/routes/__root.tsx:246
-#: src/routes/__root.tsx:295
+#: src/routes/__root.tsx:190
+#: src/routes/__root.tsx:260
+#: src/routes/__root.tsx:325
 msgid "Check-ins"
 msgstr "체크인"
 
@@ -142,15 +142,15 @@ msgid "Create a group to start hosting events."
 msgstr "그룹을 만들어 이벤트를 주최해 보세요."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:217
-#: src/routes/__root.tsx:256
+#: src/routes/__root.tsx:231
+#: src/routes/__root.tsx:270
 #: src/routes/events/index.tsx:113
 msgid "Create Event"
 msgstr "이벤트 만들기"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:214
-#: src/routes/__root.tsx:255
+#: src/routes/__root.tsx:228
+#: src/routes/__root.tsx:269
 msgid "Create Group"
 msgstr "그룹 만들기"
 
@@ -160,8 +160,8 @@ msgid "Create, discover, and RSVP to events hosted by groups across the fedivers
 msgstr "페디버스의 그룹이 주최하는 이벤트를 만들고, 발견하고, 참석하세요."
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:707
-#: src/routes/events/$eventId/index.tsx:768
+#: src/routes/events/$eventId/index.tsx:725
+#: src/routes/events/$eventId/index.tsx:786
 msgid "Dashboard"
 msgstr "대시보드"
 
@@ -176,25 +176,25 @@ msgid "Discover upcoming events from groups across the fediverse."
 msgstr "페디버스의 그룹이 주최하는 다가오는 이벤트를 발견하세요."
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:918
+#: src/routes/events/$eventId/index.tsx:941
 msgid "Discussion"
 msgstr "토론"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:697
-#: src/routes/events/$eventId/index.tsx:758
+#: src/routes/events/$eventId/index.tsx:715
+#: src/routes/events/$eventId/index.tsx:776
 msgid "Edit Event"
 msgstr "이벤트 수정"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:399
+#: src/routes/events/$eventId/index.tsx:417
 msgid "Event not found"
 msgstr "이벤트를 찾을 수 없습니다"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:175
-#: src/routes/__root.tsx:245
-#: src/routes/__root.tsx:294
+#: src/routes/__root.tsx:189
+#: src/routes/__root.tsx:259
+#: src/routes/__root.tsx:324
 #: src/routes/events/index.tsx:106
 #: src/routes/index.tsx:223
 msgid "Events"
@@ -206,7 +206,7 @@ msgid "Federated"
 msgstr "연합"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:291
+#: src/routes/__root.tsx:310
 msgid "Federated events & check-ins"
 msgstr "연합 이벤트 & 체크인"
 
@@ -222,14 +222,14 @@ msgid "Go to {0} feed page"
 msgstr "{0} 피드 페이지로 이동"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:350
+#: src/routes/events/$eventId/index.tsx:368
 msgid "Going"
 msgstr "참석 예정"
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.groupName ?? `@${event.groupHandle}`
-#: src/routes/events/$eventId/index.tsx:677
-#: src/routes/events/$eventId/index.tsx:738
+#: src/routes/events/$eventId/index.tsx:695
+#: src/routes/events/$eventId/index.tsx:756
 msgid "Hosted by <0>{0}</0>"
 msgstr "<0>{0}</0> 주최"
 
@@ -241,16 +241,21 @@ msgstr "<0>{hostLabel}</0> 주최"
 
 #. js-lingui-explicit-id
 #. placeholder {0}: event.organizerHandle
-#: src/routes/events/$eventId/index.tsx:682
-#: src/routes/events/$eventId/index.tsx:684
-#: src/routes/events/$eventId/index.tsx:743
-#: src/routes/events/$eventId/index.tsx:745
+#: src/routes/events/$eventId/index.tsx:700
+#: src/routes/events/$eventId/index.tsx:702
+#: src/routes/events/$eventId/index.tsx:761
+#: src/routes/events/$eventId/index.tsx:763
 msgid "Hosted by <0>@{0}</0>"
 msgstr "<0>@{0}</0> 주최"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:395
-#: src/routes/events/$eventId/index.tsx:1000
+#: src/routes/__root.tsx:331
+msgid "footer.legal"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:413
+#: src/routes/events/$eventId/index.tsx:1023
 #: src/routes/events/index.tsx:197
 msgid "Loading..."
 msgstr "불러오는 중..."
@@ -261,19 +266,19 @@ msgid "Moim is a federated events and places service — like connpass meets fou
 msgstr "모임은 연합형 이벤트 및 장소 서비스입니다 — connpass와 foursquare의 만남, ActivityPub 기반."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:207
-#: src/routes/__root.tsx:252
+#: src/routes/__root.tsx:221
+#: src/routes/__root.tsx:266
 msgid "My Calendar"
 msgstr "내 캘린더"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:204
-#: src/routes/__root.tsx:251
+#: src/routes/__root.tsx:218
+#: src/routes/__root.tsx:265
 msgid "My Groups"
 msgstr "내 그룹"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:928
+#: src/routes/events/$eventId/index.tsx:951
 msgid "No discussions yet."
 msgstr "아직 토론이 없습니다."
 
@@ -288,18 +293,23 @@ msgid "No upcoming events"
 msgstr "예정된 이벤트가 없습니다"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:483
-#: src/routes/events/$eventId/index.tsx:1093
+#: src/routes/events/$eventId/index.tsx:501
+#: src/routes/events/$eventId/index.tsx:1116
 msgid "Not attending"
 msgstr "불참"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:353
+#: src/routes/events/$eventId/index.tsx:371
 msgid "Not going"
 msgstr "불참"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:836
+#: src/routes/events/$eventId/index.tsx:1282
+msgid "Notices"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:859
 msgid "Organizers"
 msgstr "주최자"
 
@@ -319,40 +329,65 @@ msgid "Places"
 msgstr "장소"
 
 #. js-lingui-explicit-id
+#: src/routes/__root.tsx:334
+msgid "Privacy Policy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/index.tsx:173
 msgid "Recent Check-ins"
 msgstr "최근 체크인"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:370
-#: src/routes/events/$eventId/index.tsx:383
-#: src/routes/events/$eventId/index.tsx:500
-#: src/routes/events/$eventId/index.tsx:513
+#: src/routes/__root.tsx:335
+msgid "Refund Policy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:388
+#: src/routes/events/$eventId/index.tsx:401
+#: src/routes/events/$eventId/index.tsx:518
+#: src/routes/events/$eventId/index.tsx:531
 msgid "Register"
 msgstr "참석 신청"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:329
-#: src/routes/events/$eventId/index.tsx:460
+#: src/routes/events/$eventId/index.tsx:347
+#: src/routes/events/$eventId/index.tsx:478
 msgid "Register externally"
 msgstr "외부에서 신청"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:210
-#: src/routes/__root.tsx:253
+#: src/routes/__root.tsx:322
+msgid "footer.service"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:224
+#: src/routes/__root.tsx:267
 msgid "Settings"
 msgstr "설정"
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:235
-#: src/routes/__root.tsx:270
+#: src/routes/events/$eventId/index.tsx:1294
+msgid "notices.showAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:1292
+msgid "Show less"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/__root.tsx:249
+#: src/routes/__root.tsx:284
 #: src/routes/index.tsx:689
 msgid "Sign in"
 msgstr "로그인"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:374
-#: src/routes/events/$eventId/index.tsx:504
+#: src/routes/events/$eventId/index.tsx:392
+#: src/routes/events/$eventId/index.tsx:522
 msgid "Sign in to RSVP"
 msgstr "로그인하여 참석 신청"
 
@@ -362,13 +397,18 @@ msgid "Sign in with your fediverse account. Follow groups from Mastodon, Misskey
 msgstr "페디버스 계정으로 로그인하세요. Mastodon, Misskey 등에서 그룹을 팔로우하세요."
 
 #. js-lingui-explicit-id
-#: src/routes/__root.tsx:229
-#: src/routes/__root.tsx:264
+#: src/routes/__root.tsx:243
+#: src/routes/__root.tsx:278
 msgid "Sign out"
 msgstr "로그아웃"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:545
+#: src/routes/__root.tsx:333
+msgid "Terms of Service"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/events/$eventId/index.tsx:563
 msgid "to {endDateStr} {endTimeStr}"
 msgstr "{endDateStr} {endTimeStr}까지"
 
@@ -398,7 +438,7 @@ msgid "View Event"
 msgstr "이벤트 보기"
 
 #. js-lingui-explicit-id
-#: src/routes/events/$eventId/index.tsx:366
-#: src/routes/events/$eventId/index.tsx:496
+#: src/routes/events/$eventId/index.tsx:384
+#: src/routes/events/$eventId/index.tsx:514
 msgid "View Registration"
 msgstr "참석 신청 보기"

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -68,3 +68,15 @@ export function renderMarkdown(source: string | null | undefined): string {
   const rawHtml = md.render(source);
   return xssFilter.process(rawHtml);
 }
+
+/**
+ * Render content that may be either raw markdown or pre-rendered HTML.
+ * Detects HTML by checking for leading tags; renders markdown otherwise.
+ */
+export function renderMarkdownOrHtml(source: string | null | undefined): string {
+  if (!source || !source.trim()) return "";
+  if (source.trimStart().startsWith("<")) {
+    return xssFilter.process(source);
+  }
+  return renderMarkdown(source);
+}

--- a/src/routes/events/$eventId/dashboard/index.tsx
+++ b/src/routes/events/$eventId/dashboard/index.tsx
@@ -187,6 +187,10 @@ function ComposeNoticeDialog({
             This notice will be posted from the event&apos;s group account and delivered
             directly to each attendee&apos;s fediverse inbox.
           </p>
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Misskey users may not receive notifications unless they follow the group
+            account or change their notification settings to allow mentions from all users.
+          </p>
           <Textarea
             placeholder="Write your notice (markdown supported)..."
             value={content}

--- a/src/routes/events/$eventId/dashboard/index.tsx
+++ b/src/routes/events/$eventId/dashboard/index.tsx
@@ -1,12 +1,32 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useState, useEffect, useCallback } from "react";
 import { useDashboard } from "./route";
+import { Button } from "~/components/ui/button";
+import { Textarea } from "~/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "~/components/ui/dialog";
+import { Globe, Lock, Megaphone, Send } from "lucide-react";
 
 export const Route = createFileRoute("/events/$eventId/dashboard/")({
   component: OverviewTab,
 });
 
+type NoticeItem = {
+  id: string;
+  postId: string;
+  content: string;
+  senderHandle: string;
+  senderName: string | null;
+  createdAt: string;
+};
+
 function OverviewTab() {
-  const { data } = useDashboard();
+  const { data, eventId } = useDashboard();
   const { rsvpCounts, engagementCounts } = data;
   const isGroupEvent = !!data.event.groupActorId;
 
@@ -34,7 +54,195 @@ function OverviewTab() {
           </>
         )}
       </div>
+
+      <NoticesSection eventId={eventId} />
     </div>
+  );
+}
+
+function NoticesSection({ eventId }: { eventId: string }) {
+  const [notices, setNotices] = useState<NoticeItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const fetchNotices = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/events/${eventId}/notices?eventId=${eventId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setNotices(data.notices ?? []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchNotices();
+  }, [fetchNotices]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Megaphone className="size-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold">Notices</h3>
+        </div>
+        <Button size="sm" onClick={() => setDialogOpen(true)}>
+          <Send className="size-3.5 mr-1.5" />
+          Send Notice
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      ) : notices.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No notices sent yet. Send a notice to notify attendees about important updates.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {notices.map((notice) => (
+            <div key={notice.id} className="rounded-lg border p-4 space-y-2">
+              <div
+                className="prose prose-sm max-w-none dark:prose-invert"
+                dangerouslySetInnerHTML={{ __html: notice.content }}
+              />
+              <div className="text-xs text-muted-foreground">
+                {new Date(notice.createdAt).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ComposeNoticeDialog
+        eventId={eventId}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSent={fetchNotices}
+      />
+    </div>
+  );
+}
+
+function ComposeNoticeDialog({
+  eventId,
+  open,
+  onOpenChange,
+  onSent,
+}: {
+  eventId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSent: () => void;
+}) {
+  const [content, setContent] = useState("");
+  const [visibility, setVisibility] = useState<"unlisted" | "direct">("unlisted");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSend() {
+    if (!content.trim()) return;
+    setSending(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/events/${eventId}/notices`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: content.trim(), visibility }),
+      });
+
+      if (res.ok) {
+        setContent("");
+        onOpenChange(false);
+        onSent();
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.error ?? "Failed to send notice");
+      }
+    } catch {
+      setError("Failed to send notice");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send Notice to Attendees</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            This notice will be posted from the event&apos;s group account and delivered
+            directly to each attendee&apos;s fediverse inbox.
+          </p>
+          <Textarea
+            placeholder="Write your notice (markdown supported)..."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={5}
+            disabled={sending}
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setVisibility("unlisted")}
+              disabled={sending}
+              className={`flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors ${
+                visibility === "unlisted"
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border text-muted-foreground hover:bg-accent"
+              }`}
+            >
+              <Globe className="size-3.5" />
+              Unlisted
+            </button>
+            <button
+              type="button"
+              onClick={() => setVisibility("direct")}
+              disabled={sending}
+              className={`flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors ${
+                visibility === "direct"
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border text-muted-foreground hover:bg-accent"
+              }`}
+            >
+              <Lock className="size-3.5" />
+              Mentioned only
+            </button>
+          </div>
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={sending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSend}
+            disabled={sending || !content.trim()}
+          >
+            {sending ? "Sending..." : "Send Notice"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/routes/events/$eventId/dashboard/index.tsx
+++ b/src/routes/events/$eventId/dashboard/index.tsx
@@ -11,7 +11,7 @@ import {
   DialogFooter,
 } from "~/components/ui/dialog";
 import { Globe, Lock, Megaphone, Send } from "lucide-react";
-import { renderMarkdown } from "~/lib/markdown";
+import { renderMarkdownOrHtml } from "~/lib/markdown";
 
 export const Route = createFileRoute("/events/$eventId/dashboard/")({
   component: OverviewTab,
@@ -109,7 +109,7 @@ function NoticesSection({ eventId }: { eventId: string }) {
             <div key={notice.id} className="rounded-lg border p-4 space-y-2">
               <div
                 className="prose prose-sm max-w-none dark:prose-invert"
-                dangerouslySetInnerHTML={{ __html: renderMarkdown(notice.content) }}
+                dangerouslySetInnerHTML={{ __html: renderMarkdownOrHtml(notice.content) }}
               />
               <div className="text-xs text-muted-foreground">
                 {new Date(notice.createdAt).toLocaleDateString(undefined, {

--- a/src/routes/events/$eventId/dashboard/index.tsx
+++ b/src/routes/events/$eventId/dashboard/index.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
 } from "~/components/ui/dialog";
 import { Globe, Lock, Megaphone, Send } from "lucide-react";
+import { renderMarkdown } from "~/lib/markdown";
 
 export const Route = createFileRoute("/events/$eventId/dashboard/")({
   component: OverviewTab,
@@ -108,7 +109,7 @@ function NoticesSection({ eventId }: { eventId: string }) {
             <div key={notice.id} className="rounded-lg border p-4 space-y-2">
               <div
                 className="prose prose-sm max-w-none dark:prose-invert"
-                dangerouslySetInnerHTML={{ __html: notice.content }}
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(notice.content) }}
               />
               <div className="text-xs text-muted-foreground">
                 {new Date(notice.createdAt).toLocaleDateString(undefined, {

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -28,7 +28,7 @@ import {
 import { Separator } from "~/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/ui/tooltip";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
-import { ExternalLink, Users, Bookmark, BookmarkCheck } from "lucide-react";
+import { ExternalLink, Users, Bookmark, BookmarkCheck, Megaphone } from "lucide-react";
 import { RemoteDiscussionDialog } from "~/components/RemoteDiscussionDialog";
 import { Trans, useLingui } from "@lingui/react";
 
@@ -282,6 +282,24 @@ function EventDetailPage() {
       .then((d) => setPublicInquiries(d.inquiries ?? []))
       .catch(() => {});
   }, [eventId, isGroupEvent]);
+
+  // Public notices
+  type PublicNotice = {
+    id: string;
+    postId: string;
+    content: string;
+    senderHandle: string;
+    senderName: string | null;
+    createdAt: string;
+  };
+  const [publicNotices, setPublicNotices] = useState<PublicNotice[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/events/${eventId}/notices/public`)
+      .then((r) => r.json())
+      .then((d) => setPublicNotices(d.notices ?? []))
+      .catch(() => {});
+  }, [eventId]);
 
   const toggleThread = (inquiryId: string) => {
     if (expandedId === inquiryId) {
@@ -814,6 +832,11 @@ function EventDetailPage() {
             </CardContent>
           </Card>
 
+          {/* Notices — only shown when at least one exists */}
+          {publicNotices.length > 0 && (
+            <NoticesCard notices={publicNotices} />
+          )}
+
           {/* Description */}
           {event.description && (
             <Card className="rounded-lg">
@@ -1236,6 +1259,74 @@ function stripMentionHtml(html: string): string {
     .replace(/<p>\s+/g, "<p>")
     .trim();
   return result;
+}
+
+type PublicNoticeProps = {
+  id: string;
+  content: string;
+  createdAt: string;
+};
+
+function NoticesCard({ notices }: { notices: PublicNoticeProps[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const latest = notices[0];
+  const hasMore = notices.length > 1;
+
+  return (
+    <Card className="rounded-lg">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Megaphone className="size-4 text-muted-foreground" />
+            <CardTitle className="text-xs font-bold uppercase tracking-wide text-[#333]">
+              <Trans id="Notices" message="Notices" />
+            </CardTitle>
+          </div>
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {expanded ? (
+                <Trans id="Show less" message="Show less" />
+              ) : (
+                <Trans id="notices.showAll" message="Show all ({count})" values={{ count: notices.length }} />
+              )}
+            </button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {expanded ? (
+          <div className="space-y-2">
+            {notices.map((notice) => (
+              <NoticeItem key={notice.id} notice={notice} />
+            ))}
+          </div>
+        ) : (
+          <NoticeItem notice={latest} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function NoticeItem({ notice }: { notice: PublicNoticeProps }) {
+  return (
+    <div className="flex items-baseline gap-2 text-sm">
+      <span className="shrink-0 text-xs text-muted-foreground/60">
+        {new Date(notice.createdAt).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        })}
+      </span>
+      <div
+        className="prose prose-sm max-w-none dark:prose-invert text-muted-foreground [&>p]:m-0 [&>p]:inline"
+        dangerouslySetInnerHTML={{ __html: notice.content }}
+      />
+    </div>
+  );
 }
 
 function formatRelativeTime(dateStr: string): string {

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -1323,7 +1323,7 @@ function NoticeItem({ notice }: { notice: PublicNoticeProps }) {
       </span>
       <div
         className="prose prose-sm max-w-none dark:prose-invert text-muted-foreground [&>p]:m-0 [&>p]:inline"
-        dangerouslySetInnerHTML={{ __html: notice.content }}
+        dangerouslySetInnerHTML={{ __html: renderMarkdown(notice.content) }}
       />
     </div>
   );

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -9,7 +9,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { events, actors, users, userFediverseAccounts } from "~/server/db/schema";
 import { useEventCategoryMap } from "~/hooks/useEventCategories";
-import { renderMarkdown } from "~/lib/markdown";
+import { renderMarkdown, renderMarkdownOrHtml } from "~/lib/markdown";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import {
@@ -1269,12 +1269,12 @@ type PublicNoticeProps = {
 
 function NoticesCard({ notices }: { notices: PublicNoticeProps[] }) {
   const [expanded, setExpanded] = useState(false);
-  const latest = notices[0];
-  const hasMore = notices.length > 1;
+  const recent = notices.slice(0, 3);
+  const hasMore = notices.length > 3;
 
   return (
-    <Card className="rounded-lg">
-      <CardHeader className="pb-2">
+    <Card className="rounded-lg gap-2">
+      <CardHeader className="pb-0 pt-3 px-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Megaphone className="size-4 text-muted-foreground" />
@@ -1297,16 +1297,15 @@ function NoticesCard({ notices }: { notices: PublicNoticeProps[] }) {
           )}
         </div>
       </CardHeader>
-      <CardContent className="pt-0">
-        {expanded ? (
-          <div className="space-y-2">
-            {notices.map((notice) => (
-              <NoticeItem key={notice.id} notice={notice} />
-            ))}
-          </div>
-        ) : (
-          <NoticeItem notice={latest} />
-        )}
+      <CardContent className="pt-0 pb-2 px-4">
+        <div className="divide-y">
+          {recent.map((notice) => (
+            <NoticeItem key={notice.id} notice={notice} />
+          ))}
+          {expanded && notices.slice(3).map((notice) => (
+            <NoticeItem key={notice.id} notice={notice} />
+          ))}
+        </div>
       </CardContent>
     </Card>
   );
@@ -1314,16 +1313,16 @@ function NoticesCard({ notices }: { notices: PublicNoticeProps[] }) {
 
 function NoticeItem({ notice }: { notice: PublicNoticeProps }) {
   return (
-    <div className="flex items-baseline gap-2 text-sm">
-      <span className="shrink-0 text-xs text-muted-foreground/60">
+    <div className="flex items-start gap-2 text-sm py-3">
+      <span className="shrink-0 text-xs text-muted-foreground/60 leading-5">
         {new Date(notice.createdAt).toLocaleDateString(undefined, {
           month: "short",
           day: "numeric",
         })}
       </span>
       <div
-        className="prose prose-sm max-w-none dark:prose-invert text-muted-foreground [&>p]:m-0 [&>p]:inline"
-        dangerouslySetInnerHTML={{ __html: renderMarkdown(notice.content) }}
+        className="min-w-0 prose prose-sm max-w-none dark:prose-invert text-muted-foreground [&>p]:m-0 [&>p+p]:mt-0.5 [&>small]:text-xs"
+        dangerouslySetInnerHTML={{ __html: renderMarkdownOrHtml(notice.content) }}
       />
     </div>
   );

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -82,6 +82,8 @@ import { POST as discussionReply } from "./routes/events/-discussion-reply";
 import { PATCH as discussionUpdate } from "./routes/events/-discussion-update";
 import { GET as listDiscussionsPublic } from "./routes/events/-discussions-public";
 import { GET as discussionDetailPublic } from "./routes/events/-discussion-detail-public";
+import { POST as createEventNotice } from "./server/controllers/events/notices/create";
+import { GET as listEventNotices } from "./server/controllers/events/notices/list";
 import { POST as uploadEventHeaderImage } from "./routes/events/-upload-header-image";
 import { POST as publishEvent } from "./routes/events/-publish";
 import { DELETE as deleteEvent } from "./routes/events/-delete";
@@ -592,6 +594,36 @@ apiRouter.patch("/events/:eventId/discussions/:inquiryId", defineEventHandler(as
       eventId,
       inquiryId,
     })),
+  });
+}));
+
+// --- Event Notice endpoints ---
+apiRouter.post("/events/:eventId/notices", defineEventHandler(async (event) => {
+  const request = toWebRequest(event);
+  const eventId = event.context.params?.eventId;
+  if (!eventId) return Response.json({ error: "eventId is required" }, { status: 400 });
+
+  return createEventNotice({
+    request: await forwardJson(request, `/api/events/${eventId}/notices`, "POST", (body) => ({
+      ...(body ?? {}),
+      eventId,
+    })),
+  });
+}));
+
+apiRouter.get("/events/:eventId/notices", defineEventHandler(async (event) => {
+  const request = toWebRequest(event);
+  const eventId = event.context.params?.eventId;
+  return listEventNotices({
+    request: forwardGet(request, `/api/events/${eventId}/notices`, { eventId }),
+  });
+}));
+
+apiRouter.get("/events/:eventId/notices/public", defineEventHandler(async (event) => {
+  const request = toWebRequest(event);
+  const eventId = event.context.params?.eventId;
+  return listEventNotices({
+    request: forwardGet(request, `/api/events/${eventId}/notices/public`, { eventId, public: "1" }),
   });
 }));
 

--- a/src/server/controllers/events/notices/create.ts
+++ b/src/server/controllers/events/notices/create.ts
@@ -1,0 +1,56 @@
+import { getSessionUser } from "~/server/auth";
+import { sendEventNotice, type NoticeVisibility } from "~/server/services/event-notices";
+
+const VALID_VISIBILITIES: NoticeVisibility[] = ["unlisted", "direct"];
+
+export const POST = async ({ request }: { request: Request }) => {
+  const user = await getSessionUser(request);
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    eventId?: string;
+    content?: string;
+    visibility?: string;
+  } | null;
+
+  if (!body?.eventId || !body?.content?.trim()) {
+    return Response.json(
+      { error: "eventId and content are required" },
+      { status: 400 },
+    );
+  }
+
+  const visibility = (VALID_VISIBILITIES.includes(body.visibility as NoticeVisibility)
+    ? body.visibility
+    : "unlisted") as NoticeVisibility;
+
+  try {
+    const result = await sendEventNotice({
+      eventId: body.eventId,
+      content: body.content.trim(),
+      userId: user.id,
+      visibility,
+    });
+
+    return Response.json(
+      {
+        notice: {
+          id: result.notice.id,
+          postId: result.post.id,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Failed to send notice";
+    if (message === "Forbidden") {
+      return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (message === "Event not found") {
+      return Response.json({ error: "Event not found" }, { status: 404 });
+    }
+    return Response.json({ error: message }, { status: 500 });
+  }
+};

--- a/src/server/controllers/events/notices/list.ts
+++ b/src/server/controllers/events/notices/list.ts
@@ -1,0 +1,34 @@
+import { getSessionUser } from "~/server/auth";
+import { checkDashboardAccess } from "~/server/services/event-dashboard";
+import { listNoticesByEvent } from "~/server/repositories/event-notices";
+
+export const GET = async ({ request }: { request: Request }) => {
+  const url = new URL(request.url);
+  const eventId = url.searchParams.get("eventId");
+  if (!eventId) {
+    return Response.json({ error: "eventId is required" }, { status: 400 });
+  }
+
+  // Public access: no auth required, returns notices for any published event
+  const isPublic = url.searchParams.get("public") === "1";
+
+  if (!isPublic) {
+    const user = await getSessionUser(request);
+    if (!user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const access = await checkDashboardAccess(eventId, user.id);
+    if (!access.allowed) {
+      return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  const limit = Math.min(
+    parseInt(url.searchParams.get("limit") ?? "20", 10),
+    100,
+  );
+  const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
+
+  const result = await listNoticesByEvent(eventId, { limit, offset });
+  return Response.json(result);
+};

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -265,6 +265,14 @@ export const eventFavourites = pgTable("event_favourites", {
   uniqueFavourite: unique().on(table.userId, table.eventId),
 }));
 
+export const eventNotices = pgTable("event_notices", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  eventId: uuid("event_id").references(() => events.id).notNull(),
+  postId: uuid("post_id").references(() => posts.id).notNull(),
+  sentByUserId: uuid("sent_by_user_id").references(() => users.id).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 export const checkins = pgTable("checkins", {
   id: uuid("id").defaultRandom().primaryKey(),
   userId: uuid("user_id").references(() => users.id).notNull(),

--- a/src/server/fediverse/resolve.ts
+++ b/src/server/fediverse/resolve.ts
@@ -1,3 +1,4 @@
+import { and, eq, isNotNull } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import { actors } from "~/server/db/schema";
 import { env } from "~/server/env";
@@ -145,4 +146,28 @@ export async function persistRemoteActor(
     .returning();
 
   return actor;
+}
+
+/**
+ * Ensure a remote actor exists in the actors table with an inboxUrl.
+ * Returns the existing record if found, otherwise resolves and persists.
+ */
+export async function ensurePersistedRemoteActor(
+  handle: string,
+): Promise<typeof actors.$inferSelect> {
+  const [existing] = await db
+    .select()
+    .from(actors)
+    .where(
+      and(
+        eq(actors.handle, handle),
+        eq(actors.isLocal, false),
+        isNotNull(actors.inboxUrl),
+      ),
+    )
+    .limit(1);
+
+  if (existing) return existing;
+
+  return persistRemoteActor(handle);
 }

--- a/src/server/i18n/locales/en/messages.po
+++ b/src/server/i18n/locales/en/messages.po
@@ -1,45 +1,106 @@
 msgid ""
 msgstr ""
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Content-Type: \n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:64
 msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
 msgstr "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:128
 msgid "Map of {placeName}"
 msgstr "Map of {placeName}"
 
-msgid "{categoryLabel} Events"
-msgstr "{categoryLabel} Events"
-
-msgid "Event feed for the {categoryLabel} category on Moim."
-msgstr "Event feed for the {categoryLabel} category on Moim."
-
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:214
 msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
 msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Register here"
 msgstr "Register here"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Details"
 msgstr "Details"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:222
 msgid "RSVP here"
 msgstr "RSVP here"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:247
 msgid "Organized by: {organizers}"
 msgstr "Organized by: {organizers}"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:251
 msgid "View event details"
 msgstr "View event details"
 
-msgid "An instance actor for Moim."
-msgstr "An instance actor for Moim."
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "📢 Notice: {eventTitle}"
+msgstr "📢 Notice: {eventTitle}"
 
-msgid "page"
-msgstr "page"
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "This is a no-reply notice. For details, visit the <a href=\"{eventUrl}\">event page</a>."
+msgstr "This is a no-reply notice. For details, visit the <a href=\"{eventUrl}\">event page</a>."
 
-msgid "website"
-msgstr "website"
+#~ msgid "{categoryLabel} Events"
+#~ msgstr "{categoryLabel} Events"
 
-msgid "moderators"
-msgstr "moderators"
+#~ msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
+#~ msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
+
+#~ msgid "An instance actor for Moim."
+#~ msgstr "An instance actor for Moim."
+
+#~ msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
+#~ msgstr "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
+
+#~ msgid "Details"
+#~ msgstr "Details"
+
+#~ msgid "Event feed for the {categoryLabel} category on Moim."
+#~ msgstr "Event feed for the {categoryLabel} category on Moim."
+
+#~ msgid "Map of {placeName}"
+#~ msgstr "Map of {placeName}"
+
+#~ msgid "moderators"
+#~ msgstr "moderators"
+
+#~ msgid "Organized by: {organizers}"
+#~ msgstr "Organized by: {organizers}"
+
+#~ msgid "page"
+#~ msgstr "page"
+
+#~ msgid "Register here"
+#~ msgstr "Register here"
+
+#~ msgid "RSVP here"
+#~ msgstr "RSVP here"
+
+#~ msgid "View event details"
+#~ msgstr "View event details"
+
+#~ msgid "website"
+#~ msgstr "website"

--- a/src/server/i18n/locales/ja/messages.po
+++ b/src/server/i18n/locales/ja/messages.po
@@ -1,45 +1,106 @@
 msgid ""
 msgstr ""
 "Language: ja\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Content-Type: \n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:64
 msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
-msgstr "<a href=\"{placeUrl}\">{placeName}</a>にチェックイン"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:128
 msgid "Map of {placeName}"
-msgstr "{placeName}の地図"
+msgstr ""
 
-msgid "{categoryLabel} Events"
-msgstr "{categoryLabel} イベント"
-
-msgid "Event feed for the {categoryLabel} category on Moim."
-msgstr "Moimの{categoryLabel}カテゴリのイベントフィードです。"
-
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:214
 msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
-msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> さんがイベントを開催します！"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Register here"
-msgstr "参加登録"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Details"
-msgstr "詳細"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:222
 msgid "RSVP here"
-msgstr "参加する"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:247
 msgid "Organized by: {organizers}"
-msgstr "主催: {organizers}"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:251
 msgid "View event details"
-msgstr "イベント詳細を見る"
+msgstr ""
 
-msgid "An instance actor for Moim."
-msgstr "Moimのインスタンスアクターです。"
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "📢 Notice: {eventTitle}"
+msgstr "📢 お知らせ: {eventTitle}"
 
-msgid "page"
-msgstr "ページ"
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "This is a no-reply notice. For details, visit the <a href=\"{eventUrl}\">event page</a>."
+msgstr "この通知には返信できません。詳細は<a href=\"{eventUrl}\">イベントページ</a>をご覧ください。"
 
-msgid "website"
-msgstr "ウェブサイト"
+#~ msgid "{categoryLabel} Events"
+#~ msgstr "{categoryLabel} イベント"
 
-msgid "moderators"
-msgstr "モデレーター"
+#~ msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
+#~ msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> さんがイベントを開催します！"
+
+#~ msgid "An instance actor for Moim."
+#~ msgstr "Moimのインスタンスアクターです。"
+
+#~ msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
+#~ msgstr "<a href=\"{placeUrl}\">{placeName}</a>にチェックイン"
+
+#~ msgid "Details"
+#~ msgstr "詳細"
+
+#~ msgid "Event feed for the {categoryLabel} category on Moim."
+#~ msgstr "Moimの{categoryLabel}カテゴリのイベントフィードです。"
+
+#~ msgid "Map of {placeName}"
+#~ msgstr "{placeName}の地図"
+
+#~ msgid "moderators"
+#~ msgstr "モデレーター"
+
+#~ msgid "Organized by: {organizers}"
+#~ msgstr "主催: {organizers}"
+
+#~ msgid "page"
+#~ msgstr "ページ"
+
+#~ msgid "Register here"
+#~ msgstr "参加登録"
+
+#~ msgid "RSVP here"
+#~ msgstr "参加する"
+
+#~ msgid "View event details"
+#~ msgstr "イベント詳細を見る"
+
+#~ msgid "website"
+#~ msgstr "ウェブサイト"

--- a/src/server/i18n/locales/ko/messages.po
+++ b/src/server/i18n/locales/ko/messages.po
@@ -1,45 +1,106 @@
 msgid ""
 msgstr ""
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Content-Type: \n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:64
 msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
-msgstr "<a href=\"{placeUrl}\">{placeName}</a>에 체크인"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/checkin.ts:128
 msgid "Map of {placeName}"
-msgstr "{placeName} 지도"
+msgstr ""
 
-msgid "{categoryLabel} Events"
-msgstr "{categoryLabel} 이벤트"
-
-msgid "Event feed for the {categoryLabel} category on Moim."
-msgstr "Moim의 {categoryLabel} 카테고리 이벤트 피드입니다."
-
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:214
 msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
-msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> 님이 이벤트를 개최합니다!"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Register here"
-msgstr "참가 신청"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:221
+#: src/server/fediverse/category.ts:250
 msgid "Details"
-msgstr "자세히 보기"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:222
 msgid "RSVP here"
-msgstr "참가 신청하기"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:247
 msgid "Organized by: {organizers}"
-msgstr "주최: {organizers}"
+msgstr ""
 
+#. js-lingui-explicit-id
+#: src/server/fediverse/category.ts:251
 msgid "View event details"
-msgstr "이벤트 상세 보기"
+msgstr ""
 
-msgid "An instance actor for Moim."
-msgstr "Moim의 인스턴스 액터입니다."
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "📢 Notice: {eventTitle}"
+msgstr "📢 공지: {eventTitle}"
 
-msgid "page"
-msgstr "페이지"
+#. js-lingui-explicit-id
+#: src/server/services/event-notices.ts
+msgid "This is a no-reply notice. For details, visit the <a href=\"{eventUrl}\">event page</a>."
+msgstr "이 공지는 답장이 불가합니다. 자세한 내용은 <a href=\"{eventUrl}\">이벤트 페이지</a>를 방문해 주세요."
 
-msgid "website"
-msgstr "웹사이트"
+#~ msgid "{categoryLabel} Events"
+#~ msgstr "{categoryLabel} 이벤트"
 
-msgid "moderators"
-msgstr "운영진"
+#~ msgid "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> is hosting an event!"
+#~ msgstr "<a href=\"{actorUrl}\" class=\"u-url mention\">@{handle}</a> 님이 이벤트를 개최합니다!"
+
+#~ msgid "An instance actor for Moim."
+#~ msgstr "Moim의 인스턴스 액터입니다."
+
+#~ msgid "Checked in at <a href=\"{placeUrl}\">{placeName}</a>"
+#~ msgstr "<a href=\"{placeUrl}\">{placeName}</a>에 체크인"
+
+#~ msgid "Details"
+#~ msgstr "자세히 보기"
+
+#~ msgid "Event feed for the {categoryLabel} category on Moim."
+#~ msgstr "Moim의 {categoryLabel} 카테고리 이벤트 피드입니다."
+
+#~ msgid "Map of {placeName}"
+#~ msgstr "{placeName} 지도"
+
+#~ msgid "moderators"
+#~ msgstr "운영진"
+
+#~ msgid "Organized by: {organizers}"
+#~ msgstr "주최: {organizers}"
+
+#~ msgid "page"
+#~ msgstr "페이지"
+
+#~ msgid "Register here"
+#~ msgstr "참가 신청"
+
+#~ msgid "RSVP here"
+#~ msgstr "참가 신청하기"
+
+#~ msgid "View event details"
+#~ msgstr "이벤트 상세 보기"
+
+#~ msgid "website"
+#~ msgstr "웹사이트"

--- a/src/server/repositories/event-notices.ts
+++ b/src/server/repositories/event-notices.ts
@@ -1,0 +1,48 @@
+import { eq, desc, count } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import { eventNotices, posts, actors } from "~/server/db/schema";
+
+export async function createNoticeRecord(params: {
+  eventId: string;
+  postId: string;
+  sentByUserId: string;
+}) {
+  const [row] = await db
+    .insert(eventNotices)
+    .values(params)
+    .returning();
+  return row;
+}
+
+export async function listNoticesByEvent(
+  eventId: string,
+  opts?: { limit?: number; offset?: number },
+) {
+  const limit = opts?.limit ?? 20;
+  const offset = opts?.offset ?? 0;
+
+  const [notices, [{ total }]] = await Promise.all([
+    db
+      .select({
+        id: eventNotices.id,
+        postId: eventNotices.postId,
+        content: posts.content,
+        senderHandle: actors.handle,
+        senderName: actors.name,
+        createdAt: eventNotices.createdAt,
+      })
+      .from(eventNotices)
+      .innerJoin(posts, eq(eventNotices.postId, posts.id))
+      .innerJoin(actors, eq(posts.actorId, actors.id))
+      .where(eq(eventNotices.eventId, eventId))
+      .orderBy(desc(eventNotices.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ total: count() })
+      .from(eventNotices)
+      .where(eq(eventNotices.eventId, eventId)),
+  ]);
+
+  return { notices, total };
+}

--- a/src/server/services/event-notices.ts
+++ b/src/server/services/event-notices.ts
@@ -12,6 +12,7 @@ import {
   groupMembers,
 } from "~/server/db/schema";
 import { getFederationContext } from "~/server/fediverse/federation";
+import { ensurePersistedRemoteActor } from "~/server/fediverse/resolve";
 import { createNoticeRecord } from "~/server/repositories/event-notices";
 import { renderMarkdown } from "~/lib/markdown";
 
@@ -104,13 +105,11 @@ export async function sendEventNotice(
     })
     .returning();
 
-  // 5. Resolve attendee recipients (remote fediverse actors with inboxUrl)
-  // Join: rsvps → userFediverseAccounts (primary) → actors (remote, has inbox)
-  const attendeeActors = await db
+  // 5. Resolve attendee recipients
+  // First get all accepted attendees' primary fediverse handles
+  const attendeeHandles = await db
     .select({
-      actorUrl: actors.actorUrl,
-      inboxUrl: actors.inboxUrl,
-      handle: actors.handle,
+      fediverseHandle: userFediverseAccounts.fediverseHandle,
     })
     .from(rsvps)
     .innerJoin(
@@ -120,14 +119,6 @@ export async function sendEventNotice(
         eq(userFediverseAccounts.isPrimary, true),
       ),
     )
-    .innerJoin(
-      actors,
-      and(
-        eq(actors.handle, userFediverseAccounts.fediverseHandle),
-        eq(actors.isLocal, false),
-        isNotNull(actors.inboxUrl),
-      ),
-    )
     .where(
       and(
         eq(rsvps.eventId, eventId),
@@ -135,6 +126,21 @@ export async function sendEventNotice(
         isNotNull(rsvps.userId),
       ),
     );
+
+  // Ensure each attendee has a persisted remote actor (lazy resolution)
+  const attendeeActors = (
+    await Promise.all(
+      attendeeHandles.map(async ({ fediverseHandle }) => {
+        try {
+          return await ensurePersistedRemoteActor(fediverseHandle);
+        } catch {
+          return null;
+        }
+      }),
+    )
+  ).filter(
+    (a): a is NonNullable<typeof a> => a != null && !!a.inboxUrl,
+  );
 
   // 6. Create notice metadata record
   const notice = await createNoticeRecord({
@@ -149,8 +155,7 @@ export async function sendEventNotice(
   const noteUri = ctx.getObjectUri(Note, { noteId: post.id });
   const published = Temporal.Instant.from(now.toISOString());
 
-  const validAttendees = attendeeActors.filter((a) => a.inboxUrl);
-  const attendeeUris = validAttendees.map((a) => new URL(a.actorUrl));
+  const attendeeUris = attendeeActors.map((a) => new URL(a.actorUrl));
 
   // Build to/cc based on visibility
   let tos: URL[];
@@ -165,8 +170,8 @@ export async function sendEventNotice(
   }
 
   // Include Mention tags for small attendee lists (≤50)
-  const mentions = validAttendees.length <= 50
-    ? validAttendees.map((a) => new Mention({
+  const mentions = attendeeActors.length <= 50
+    ? attendeeActors.map((a) => new Mention({
         href: new URL(a.actorUrl),
         name: `@${a.handle}`,
       }))
@@ -202,12 +207,11 @@ export async function sendEventNotice(
 
   // 9. Direct delivery to each attendee's inbox
   for (const attendee of attendeeActors) {
-    if (!attendee.inboxUrl) continue;
     await ctx.sendActivity(
       { identifier: senderHandle },
       {
         id: new URL(attendee.actorUrl),
-        inboxId: new URL(attendee.inboxUrl),
+        inboxId: new URL(attendee.inboxUrl!),
       },
       createActivity,
       { immediate: true },

--- a/src/server/services/event-notices.ts
+++ b/src/server/services/event-notices.ts
@@ -1,0 +1,218 @@
+import { Create, Mention, Note, PUBLIC_COLLECTION } from "@fedify/fedify";
+import { Temporal } from "@js-temporal/polyfill";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "~/server/db/client";
+import {
+  events,
+  rsvps,
+  actors,
+  posts,
+  eventNotices,
+  userFediverseAccounts,
+  groupMembers,
+} from "~/server/db/schema";
+import { getFederationContext } from "~/server/fediverse/federation";
+import { createNoticeRecord } from "~/server/repositories/event-notices";
+import { renderMarkdown } from "~/lib/markdown";
+
+export type NoticeVisibility = "unlisted" | "direct";
+
+export interface SendNoticeParams {
+  eventId: string;
+  content: string;
+  userId: string;
+  visibility: NoticeVisibility;
+}
+
+export interface SendNoticeResult {
+  notice: typeof eventNotices.$inferSelect;
+  post: typeof posts.$inferSelect;
+}
+
+export async function sendEventNotice(
+  params: SendNoticeParams,
+): Promise<SendNoticeResult> {
+  const { eventId, content, userId, visibility } = params;
+
+  // 1. Fetch event
+  const [event] = await db
+    .select({
+      id: events.id,
+      organizerId: events.organizerId,
+      groupActorId: events.groupActorId,
+    })
+    .from(events)
+    .where(eq(events.id, eventId))
+    .limit(1);
+
+  if (!event) throw new Error("Event not found");
+
+  // 2. Authorization
+  if (event.groupActorId) {
+    const [membership] = await db
+      .select({ role: groupMembers.role })
+      .from(groupMembers)
+      .innerJoin(actors, eq(groupMembers.memberActorId, actors.id))
+      .where(
+        and(
+          eq(groupMembers.groupActorId, event.groupActorId),
+          eq(actors.userId, userId),
+          eq(actors.type, "Person"),
+        ),
+      )
+      .limit(1);
+    if (!membership) throw new Error("Forbidden");
+  } else {
+    if (event.organizerId !== userId) throw new Error("Forbidden");
+  }
+
+  // 3. Resolve sending actor (Group for group events, local Person for personal)
+  let sendingActor;
+  if (event.groupActorId) {
+    [sendingActor] = await db
+      .select()
+      .from(actors)
+      .where(and(eq(actors.id, event.groupActorId), eq(actors.isLocal, true)))
+      .limit(1);
+  } else {
+    [sendingActor] = await db
+      .select()
+      .from(actors)
+      .where(
+        and(
+          eq(actors.userId, userId),
+          eq(actors.type, "Person"),
+          eq(actors.isLocal, true),
+        ),
+      )
+      .limit(1);
+  }
+
+  if (!sendingActor) throw new Error("No local actor found for sending");
+
+  // 4. Render markdown to HTML and create post record
+  const htmlContent = renderMarkdown(content);
+  const now = new Date();
+  const [post] = await db
+    .insert(posts)
+    .values({
+      actorId: sendingActor.id,
+      eventId,
+      content: htmlContent,
+      visibility,
+      published: now,
+    })
+    .returning();
+
+  // 5. Resolve attendee recipients (remote fediverse actors with inboxUrl)
+  // Join: rsvps → userFediverseAccounts (primary) → actors (remote, has inbox)
+  const attendeeActors = await db
+    .select({
+      actorUrl: actors.actorUrl,
+      inboxUrl: actors.inboxUrl,
+      handle: actors.handle,
+    })
+    .from(rsvps)
+    .innerJoin(
+      userFediverseAccounts,
+      and(
+        eq(rsvps.userId, userFediverseAccounts.userId),
+        eq(userFediverseAccounts.isPrimary, true),
+      ),
+    )
+    .innerJoin(
+      actors,
+      and(
+        eq(actors.handle, userFediverseAccounts.fediverseHandle),
+        eq(actors.isLocal, false),
+        isNotNull(actors.inboxUrl),
+      ),
+    )
+    .where(
+      and(
+        eq(rsvps.eventId, eventId),
+        eq(rsvps.status, "accepted"),
+        isNotNull(rsvps.userId),
+      ),
+    );
+
+  // 6. Create notice metadata record
+  const notice = await createNoticeRecord({
+    eventId,
+    postId: post.id,
+    sentByUserId: userId,
+  });
+
+  // 7. Compose AP Note + Create activity
+  const ctx = getFederationContext();
+  const senderHandle = sendingActor.handle;
+  const noteUri = ctx.getObjectUri(Note, { noteId: post.id });
+  const published = Temporal.Instant.from(now.toISOString());
+
+  const validAttendees = attendeeActors.filter((a) => a.inboxUrl);
+  const attendeeUris = validAttendees.map((a) => new URL(a.actorUrl));
+
+  // Build to/cc based on visibility
+  let tos: URL[];
+  let ccs: URL[];
+
+  if (visibility === "direct") {
+    tos = attendeeUris;
+    ccs = [];
+  } else {
+    tos = [ctx.getFollowersUri(senderHandle), ...attendeeUris];
+    ccs = [PUBLIC_COLLECTION];
+  }
+
+  // Include Mention tags for small attendee lists (≤50)
+  const mentions = validAttendees.length <= 50
+    ? validAttendees.map((a) => new Mention({
+        href: new URL(a.actorUrl),
+        name: `@${a.handle}`,
+      }))
+    : [];
+
+  const note = new Note({
+    id: noteUri,
+    attribution: ctx.getActorUri(senderHandle),
+    content: htmlContent,
+    published,
+    tos,
+    ccs,
+    tags: mentions.length > 0 ? mentions : [],
+  });
+
+  const createActivity = new Create({
+    id: new URL(`${noteUri.href}#activity`),
+    actor: ctx.getActorUri(senderHandle),
+    object: note,
+    published,
+    tos,
+    ccs,
+  });
+
+  // 8. Send to followers (only for unlisted)
+  if (visibility === "unlisted") {
+    await ctx.sendActivity(
+      { identifier: senderHandle },
+      "followers",
+      createActivity,
+    );
+  }
+
+  // 9. Direct delivery to each attendee's inbox
+  for (const attendee of attendeeActors) {
+    if (!attendee.inboxUrl) continue;
+    await ctx.sendActivity(
+      { identifier: senderHandle },
+      {
+        id: new URL(attendee.actorUrl),
+        inboxId: new URL(attendee.inboxUrl),
+      },
+      createActivity,
+      { immediate: true },
+    );
+  }
+
+  return { notice, post };
+}

--- a/src/server/services/event-notices.ts
+++ b/src/server/services/event-notices.ts
@@ -12,6 +12,7 @@ import {
   groupMembers,
 } from "~/server/db/schema";
 import { getFederationContext } from "~/server/fediverse/federation";
+import { getI18n } from "~/server/i18n";
 import { ensurePersistedRemoteActor } from "~/server/fediverse/resolve";
 import { createNoticeRecord } from "~/server/repositories/event-notices";
 import { renderMarkdown } from "~/lib/markdown";
@@ -39,6 +40,7 @@ export async function sendEventNotice(
   const [event] = await db
     .select({
       id: events.id,
+      title: events.title,
       organizerId: events.organizerId,
       groupActorId: events.groupActorId,
     })
@@ -91,19 +93,29 @@ export async function sendEventNotice(
 
   if (!sendingActor) throw new Error("No local actor found for sending");
 
-  // 4. Render markdown to HTML and create post record
-  const htmlContent = renderMarkdown(content);
+  // 4. Store raw markdown in DB, build AP HTML separately
+  const i18n = getI18n(sendingActor.language);
+  const fedCtx = getFederationContext();
   const now = new Date();
   const [post] = await db
     .insert(posts)
     .values({
       actorId: sendingActor.id,
       eventId,
-      content: htmlContent,
+      content,
       visibility,
       published: now,
     })
     .returning();
+
+  // Build HTML with header/footer for AP delivery only
+  const bodyHtml = renderMarkdown(content);
+  const eventUrl = new URL(`/events/${eventId}`, fedCtx.canonicalOrigin).href;
+  const apHtmlContent = [
+    `<p><strong>${i18n._("📢 Notice: {eventTitle}", { eventTitle: event.title })}</strong></p>`,
+    bodyHtml,
+    `<p><small>${i18n._("This is a no-reply notice. For details, visit the <a href=\"{eventUrl}\">event page</a>.", { eventUrl })}</small></p>`,
+  ].join("\n");
 
   // 5. Resolve attendee recipients
   // First get all accepted attendees' primary fediverse handles
@@ -150,7 +162,7 @@ export async function sendEventNotice(
   });
 
   // 7. Compose AP Note + Create activity
-  const ctx = getFederationContext();
+  const ctx = fedCtx;
   const senderHandle = sendingActor.handle;
   const noteUri = ctx.getObjectUri(Note, { noteId: post.id });
   const published = Temporal.Instant.from(now.toISOString());
@@ -180,7 +192,7 @@ export async function sendEventNotice(
   const note = new Note({
     id: noteUri,
     attribution: ctx.getActorUri(senderHandle),
-    content: htmlContent,
+    content: apHtmlContent,
     published,
     tos,
     ccs,


### PR DESCRIPTION
## Summary

Event organizers can now send notices to RSVP'd attendees from the dashboard overview page. Notices are delivered as ActivityPub Notes to each attendee's fediverse inbox and optionally posted to followers. Notices are persisted in a new `eventNotices` table and displayed on both the dashboard and the public event detail page.

Key features:
- Compose dialog with markdown support and visibility toggle (unlisted / mentioned only)
- Federated delivery with Mention tags for ≤50 attendees
- Lazy remote actor resolution via `ensurePersistedRemoteActor` (fixes delivery for MiAuth/OAuth users)
- i18n notice header/footer for AP delivery (en/ko/ja), raw markdown stored in DB
- Collapsible notices section on event page showing 3 most recent with dividers
- Misskey notification limitation caution in compose dialog

## Test plan
- [x] Create an event with RSVPs, send a notice from the dashboard overview
- [x] Verify notice appears on the event detail page (collapsible, renders markdown)
- [x] Verify AP delivery to Mastodon attendees (should receive notification)
- [x] Verify notice listing via `GET /api/events/:eventId/notices/public`
- [x] Test visibility toggle: unlisted posts to followers, direct delivers only to attendees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Event organizers can send notices to attendees with configurable visibility options.
- Public notices are now displayed on event detail pages.
- Added a notices management section in the event organizer dashboard to compose and send announcements.
- Expanded internationalization support with new notice-related UI strings across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->