### PR TITLE
Allow co-organizers to preview attendee list

### DIFF
--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -1093,17 +1093,17 @@ function EventDetailPage() {
                 ) : (
                   <ul className="space-y-3">
                     {attendeesData.attendees.map((a) => (
-                      <li key={a.userId} className="border rounded-md p-3 space-y-2">
+                      <li key={a.userId} className="border rounded-md p-3 space-y-2 overflow-hidden">
                         <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-2 min-w-0">
                             <Avatar className="size-8 shrink-0">
                               {a.avatarUrl && <AvatarImage src={a.avatarUrl} alt={a.displayName} />}
                               <AvatarFallback className="text-xs">
                                 {a.displayName.charAt(0).toUpperCase()}
                               </AvatarFallback>
                             </Avatar>
-                            <div>
-                              <div>
+                            <div className="min-w-0">
+                              <div className="truncate">
                                 <span className="text-sm font-medium">{a.displayName}</span>
                                 <span className="text-sm text-muted-foreground ml-1.5">@{a.handle}</span>
                               </div>
@@ -1112,7 +1112,7 @@ function EventDetailPage() {
                               )}
                             </div>
                           </div>
-                          <Badge variant={a.status === "accepted" ? "default" : "secondary"}>
+                          <Badge variant={a.status === "accepted" ? "default" : "secondary"} className="shrink-0">
                             {a.status === "accepted" ? <Trans id="Attending" message="Attending" /> : <Trans id="Not attending" message="Not attending" />}
                           </Badge>
                         </div>
@@ -1123,8 +1123,8 @@ function EventDetailPage() {
                               if (!ans) return null;
                               return (
                                 <div key={q.id}>
-                                  <p className="text-xs text-muted-foreground">{q.question}</p>
-                                  <p className="text-sm">{ans.answer}</p>
+                                  <p className="text-xs text-muted-foreground break-all">{q.question}</p>
+                                  <p className="text-sm break-all">{ans.answer}</p>
                                 </div>
                               );
                             })}

--- a/src/routes/events/$eventId/register.tsx
+++ b/src/routes/events/$eventId/register.tsx
@@ -659,11 +659,11 @@ function RegisterPage() {
 
       {/* Step: Questions */}
       {currentStepType === "questions" && (
-        <div className="space-y-6">
+        <div className="space-y-6 overflow-hidden">
           <h2 className="text-lg font-semibold">Registration questions</h2>
           {questions.map((q, i) => (
             <div key={q.id} className="space-y-3">
-              <Label className="leading-relaxed">
+              <Label className="leading-relaxed block break-all select-text">
                 {i + 1}. {q.question}
                 {q.required && <span className="text-destructive ml-1">*</span>}
               </Label>

--- a/src/server/controllers/events/attendees.ts
+++ b/src/server/controllers/events/attendees.ts
@@ -5,6 +5,7 @@ import {
   rsvps,
   rsvpAnswers,
   eventQuestions,
+  eventOrganizers,
   eventTiers,
   users,
   actors,
@@ -28,7 +29,7 @@ export const GET = async ({ request }: { request: Request }) => {
 
   // Get event and its group
   const [event] = await db
-    .select({ id: events.id, groupActorId: events.groupActorId })
+    .select({ id: events.id, organizerId: events.organizerId, groupActorId: events.groupActorId })
     .from(events)
     .where(eq(events.id, eventId))
     .limit(1);
@@ -37,8 +38,16 @@ export const GET = async ({ request }: { request: Request }) => {
     return Response.json({ error: "Event not found" }, { status: 404 });
   }
 
-  // Check if user is organizer/moderator of the group
-  if (event.groupActorId) {
+  // Check if user is organizer, group member, or co-organizer
+  let hasAccess = false;
+
+  // Event owner
+  if (event.organizerId === user.id) {
+    hasAccess = true;
+  }
+
+  // Group member (owner/moderator)
+  if (!hasAccess && event.groupActorId) {
     const [membership] = await db
       .select({ role: groupMembers.role })
       .from(groupMembers)
@@ -51,10 +60,27 @@ export const GET = async ({ request }: { request: Request }) => {
         ),
       )
       .limit(1);
+    if (membership) hasAccess = true;
+  }
 
-    if (!membership) {
-      return Response.json({ error: "Forbidden" }, { status: 403 });
-    }
+  // Co-organizer listed in eventOrganizers
+  if (!hasAccess) {
+    const [coOrg] = await db
+      .select({ id: eventOrganizers.id })
+      .from(eventOrganizers)
+      .innerJoin(actors, eq(eventOrganizers.actorId, actors.id))
+      .where(
+        and(
+          eq(eventOrganizers.eventId, eventId),
+          eq(actors.userId, user.id),
+        ),
+      )
+      .limit(1);
+    if (coOrg) hasAccess = true;
+  }
+
+  if (!hasAccess) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   // Get questions for this event

--- a/src/server/controllers/events/attendees.ts
+++ b/src/server/controllers/events/attendees.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, or } from "drizzle-orm";
 import { db } from "~/server/db/client";
 import {
   events,
@@ -64,15 +64,23 @@ export const GET = async ({ request }: { request: Request }) => {
   }
 
   // Co-organizer listed in eventOrganizers
+  // Match via actors.userId OR via userFediverseAccounts (for remote actors without userId)
   if (!hasAccess) {
     const [coOrg] = await db
       .select({ id: eventOrganizers.id })
       .from(eventOrganizers)
       .innerJoin(actors, eq(eventOrganizers.actorId, actors.id))
+      .leftJoin(
+        userFediverseAccounts,
+        eq(actors.handle, userFediverseAccounts.fediverseHandle),
+      )
       .where(
         and(
           eq(eventOrganizers.eventId, eventId),
-          eq(actors.userId, user.id),
+          or(
+            eq(actors.userId, user.id),
+            eq(userFediverseAccounts.userId, user.id),
+          ),
         ),
       )
       .limit(1);


### PR DESCRIPTION
## Summary

Co-organizers listed in `eventOrganizers` can now view the attendee list on the event detail page. The access check matches co-organizers via both `actors.userId` and `userFediverseAccounts` to handle remote actors without a local userId. Also fixes text overflow issues in the attendee card and registration question labels.

## Test plan
- [ ] Add a co-organizer to an event, verify they can see the attendee list
- [ ] Test with a co-organizer whose actor is a remote fediverse account (no userId)
- [ ] Verify long question labels wrap correctly in the registration form
- [ ] Verify long Q&A text in attendee cards doesn't overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced attendee list UI with improved text handling for long names and content, preventing layout overflow while maintaining visual stability
  * Improved text wrapping and selection behavior in event registration form questions for better content display

* **New Features**
  * Event owners and co-organizers now have access permissions to view attendee information and details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->