### PR TITLE
Online event support with auto country via organizer geolocation

### DIFF
--- a/drizzle/0048_wonderful_nehzno.sql
+++ b/drizzle/0048_wonderful_nehzno.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "event_type" varchar(16) DEFAULT 'in_person' NOT NULL;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "meeting_url" text;

--- a/drizzle/meta/0048_snapshot.json
+++ b/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,3108 @@
+{
+  "id": "4539f0f6-c409-418d-ab91-e703714965b9",
+  "prevId": "19cdf880-1306-4fa5-9590-9712d76ffcb0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_url": {
+          "name": "activity_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_post_id": {
+          "name": "reply_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_actor_id_actors_id_fk": {
+          "name": "activity_logs_actor_id_actors_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_post_id_posts_id_fk": {
+          "name": "activity_logs_post_id_posts_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_event_id_events_id_fk": {
+          "name": "activity_logs_event_id_events_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_reply_post_id_posts_id_fk": {
+          "name": "activity_logs_reply_post_id_posts_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "reply_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_logs_actor_id_post_id_type_emoji_unique": {
+          "name": "activity_logs_actor_id_post_id_type_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "post_id",
+            "type",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actors": {
+      "name": "actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Person'"
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_url": {
+          "name": "outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_url": {
+          "name": "following_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_local": {
+          "name": "is_local",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "manually_approves_followers": {
+          "name": "manually_approves_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actors_user_id_users_id_fk": {
+          "name": "actors_user_id_users_id_fk",
+          "tableFrom": "actors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actors_handle_unique": {
+          "name": "actors_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h3_index": {
+          "name": "h3_index",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hop_count": {
+          "name": "hop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impression_count": {
+          "name": "impression_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkins": {
+      "name": "checkins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkins_user_id_users_id_fk": {
+          "name": "checkins_user_id_users_id_fk",
+          "tableFrom": "checkins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "checkins_place_id_places_id_fk": {
+          "name": "checkins_place_id_places_id_fk",
+          "tableFrom": "checkins",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alpha3": {
+          "name": "alpha3",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bbox": {
+          "name": "bbox",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_categories": {
+      "name": "event_categories",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_favourites": {
+      "name": "event_favourites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_favourites_user_id_users_id_fk": {
+          "name": "event_favourites_user_id_users_id_fk",
+          "tableFrom": "event_favourites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_favourites_event_id_events_id_fk": {
+          "name": "event_favourites_event_id_events_id_fk",
+          "tableFrom": "event_favourites",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_favourites_user_id_event_id_unique": {
+          "name": "event_favourites_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_notices": {
+      "name": "event_notices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_notices_event_id_events_id_fk": {
+          "name": "event_notices_event_id_events_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_notices_post_id_posts_id_fk": {
+          "name": "event_notices_post_id_posts_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_notices_sent_by_user_id_users_id_fk": {
+          "name": "event_notices_sent_by_user_id_users_id_fk",
+          "tableFrom": "event_notices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_organizers": {
+      "name": "event_organizers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_organizers_event_id_events_id_fk": {
+          "name": "event_organizers_event_id_events_id_fk",
+          "tableFrom": "event_organizers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizers_actor_id_actors_id_fk": {
+          "name": "event_organizers_actor_id_actors_id_fk",
+          "tableFrom": "event_organizers",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_questions": {
+      "name": "event_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_questions_event_id_events_id_fk": {
+          "name": "event_questions_event_id_events_id_fk",
+          "tableFrom": "event_questions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tags": {
+      "name": "event_tags",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_tags_tag_id_tags_id_fk": {
+          "name": "event_tags_tag_id_tags_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_tags_event_id_tag_id_pk": {
+          "name": "event_tags_event_id_tag_id_pk",
+          "columns": [
+            "event_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tiers": {
+      "name": "event_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tiers_event_id_events_id_fk": {
+          "name": "event_tiers_event_id_events_id_fk",
+          "tableFrom": "event_tiers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue_detail": {
+          "name": "venue_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_person'"
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_image_url": {
+          "name": "header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allow_anonymous_rsvp": {
+          "name": "allow_anonymous_rsvp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "anonymous_contact_fields": {
+          "name": "anonymous_contact_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_organizer_id_users_id_fk": {
+          "name": "events_organizer_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_group_actor_id_actors_id_fk": {
+          "name": "events_group_actor_id_actors_id_fk",
+          "tableFrom": "events",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_category_id_event_categories_slug_fk": {
+          "name": "events_category_id_event_categories_slug_fk",
+          "tableFrom": "events",
+          "tableTo": "event_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_place_id_places_id_fk": {
+          "name": "events_place_id_places_id_fk",
+          "tableFrom": "events",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_actors_id_fk": {
+          "name": "follows_follower_id_actors_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_actors_id_fk": {
+          "name": "follows_following_id_actors_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_actor_id": {
+          "name": "member_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_group_actor_id_actors_id_fk": {
+          "name": "group_members_group_actor_id_actors_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_member_actor_id_actors_id_fk": {
+          "name": "group_members_member_actor_id_actors_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "member_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_places": {
+      "name": "group_places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by_user_id": {
+          "name": "assigned_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_places_group_actor_id_actors_id_fk": {
+          "name": "group_places_group_actor_id_actors_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_places_place_id_places_id_fk": {
+          "name": "group_places_place_id_places_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_places_assigned_by_user_id_users_id_fk": {
+          "name": "group_places_assigned_by_user_id_users_id_fk",
+          "tableFrom": "group_places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_places_group_actor_id_place_id_unique": {
+          "name": "group_places_group_actor_id_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_actor_id",
+            "place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keypairs": {
+      "name": "keypairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keypairs_actor_id_actors_id_fk": {
+          "name": "keypairs_actor_id_actors_id_fk",
+          "tableFrom": "keypairs",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenges": {
+      "name": "otp_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expected_emojis": {
+          "name": "expected_emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenges_question_id_unique": {
+          "name": "otp_challenges_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_votes": {
+      "name": "otp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_actor_url": {
+          "name": "voter_actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "otp_votes_challenge_id_otp_challenges_id_fk": {
+          "name": "otp_votes_challenge_id_otp_challenges_id_fk",
+          "tableFrom": "otp_votes",
+          "tableTo": "otp_challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_votes_challenge_id_emoji_unique": {
+          "name": "otp_votes_challenge_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_audit_log": {
+      "name": "place_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_audit_log_place_id_places_id_fk": {
+          "name": "place_audit_log_place_id_places_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_audit_log_group_actor_id_actors_id_fk": {
+          "name": "place_audit_log_group_actor_id_actors_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_audit_log_user_id_users_id_fk": {
+          "name": "place_audit_log_user_id_users_id_fk",
+          "tableFrom": "place_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_categories": {
+      "name": "place_categories",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_slug": {
+          "name": "parent_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_categories_parent_slug_place_categories_slug_fk": {
+          "name": "place_categories_parent_slug_place_categories_slug_fk",
+          "tableFrom": "place_categories",
+          "tableTo": "place_categories",
+          "columnsFrom": [
+            "parent_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_tags": {
+      "name": "place_tags",
+      "schema": "",
+      "columns": {
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "place_tags_place_id_places_id_fk": {
+          "name": "place_tags_place_id_places_id_fk",
+          "tableFrom": "place_tags",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "place_tags_tag_id_tags_id_fk": {
+          "name": "place_tags_tag_id_tags_id_fk",
+          "tableFrom": "place_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "place_tags_place_id_tag_id_pk": {
+          "name": "place_tags_place_id_tag_id_pk",
+          "columns": [
+            "place_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "places_category_id_place_categories_slug_fk": {
+          "name": "places_category_id_place_categories_slug_fk",
+          "tableFrom": "places",
+          "tableTo": "place_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "places_created_by_id_users_id_fk": {
+          "name": "places_created_by_id_users_id_fk",
+          "tableFrom": "places",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_options_poll_id_polls_id_fk": {
+          "name": "poll_options_poll_id_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_actor_url": {
+          "name": "voter_actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_instance": {
+          "name": "source_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_votes_poll_id_polls_id_fk": {
+          "name": "poll_votes_poll_id_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_votes_option_id_poll_options_id_fk": {
+          "name": "poll_votes_option_id_poll_options_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_votes_poll_id_option_id_voter_actor_url_unique": {
+          "name": "poll_votes_poll_id_option_id_voter_actor_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "option_id",
+            "voter_actor_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_actor_id": {
+          "name": "group_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polls_group_actor_id_actors_id_fk": {
+          "name": "polls_group_actor_id_actors_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "group_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "polls_question_id_unique": {
+          "name": "polls_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ap_uri": {
+          "name": "ap_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to_post_id": {
+          "name": "in_reply_to_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_root_id": {
+          "name": "thread_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_status": {
+          "name": "thread_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_replied_at": {
+          "name": "last_replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_actor_id_actors_id_fk": {
+          "name": "posts_actor_id_actors_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_event_id_events_id_fk": {
+          "name": "posts_event_id_events_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_in_reply_to_post_id_posts_id_fk": {
+          "name": "posts_in_reply_to_post_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "in_reply_to_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_thread_root_id_posts_id_fk": {
+          "name": "posts_thread_root_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "thread_root_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvp_answers": {
+      "name": "rsvp_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rsvp_id": {
+          "name": "rsvp_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvp_answers_rsvp_id_rsvps_id_fk": {
+          "name": "rsvp_answers_rsvp_id_rsvps_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "rsvps",
+          "columnsFrom": [
+            "rsvp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_user_id_users_id_fk": {
+          "name": "rsvp_answers_user_id_users_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_event_id_events_id_fk": {
+          "name": "rsvp_answers_event_id_events_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvp_answers_question_id_event_questions_id_fk": {
+          "name": "rsvp_answers_question_id_event_questions_id_fk",
+          "tableFrom": "rsvp_answers",
+          "tableTo": "event_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsvp_answers_rsvp_id_question_id_unique": {
+          "name": "rsvp_answers_rsvp_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rsvp_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvps": {
+      "name": "rsvps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_user_id_users_id_fk": {
+          "name": "rsvps_user_id_users_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvps_event_id_events_id_fk": {
+          "name": "rsvps_event_id_events_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvps_tier_id_event_tiers_id_fk": {
+          "name": "rsvps_tier_id_event_tiers_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "event_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fediverse_accounts": {
+      "name": "user_fediverse_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fediverse_handle": {
+          "name": "fediverse_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_handle": {
+          "name": "proxy_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_fediverse_accounts_user_id_users_id_fk": {
+          "name": "user_fediverse_accounts_user_id_users_id_fk",
+          "tableFrom": "user_fediverse_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_fediverse_accounts_fediverse_handle_unique": {
+          "name": "user_fediverse_accounts_fediverse_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fediverse_handle"
+          ]
+        },
+        "user_fediverse_accounts_proxy_handle_unique": {
+          "name": "user_fediverse_accounts_proxy_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proxy_handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fediverse_handle": {
+          "name": "fediverse_handle",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_source_hash": {
+          "name": "avatar_source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1775616861332,
       "tag": "0047_broad_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1776408696065,
+      "tag": "0048_wonderful_nehzno",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/event-form/WhereCard.tsx
+++ b/src/components/event-form/WhereCard.tsx
@@ -1,45 +1,162 @@
+import { useEffect } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { cn } from "~/lib/utils";
 import { PlacePicker, type SelectedPlace } from "~/components/PlacePicker";
 
+export type EventType = "in_person" | "online";
+
 type WhereCardProps = {
+  eventType: EventType;
+  onEventTypeChange: (value: EventType) => void;
   selectedPlace: SelectedPlace | null;
   onSelectedPlaceChange: (place: SelectedPlace | null) => void;
   venueDetail: string;
   onVenueDetailChange: (value: string) => void;
+  meetingUrl: string;
+  onMeetingUrlChange: (value: string) => void;
+  /** Silently emitted when eventType=online and the browser already has
+   *  geolocation permission. Consumed by the server only to reverse-geocode
+   *  a country code — never persisted. */
+  onOrganizerCoordsChange: (coords: { lat: number; lng: number } | null) => void;
   groupActorId?: string;
 };
 
 export function WhereCard({
+  eventType,
+  onEventTypeChange,
   selectedPlace,
   onSelectedPlaceChange,
   venueDetail,
   onVenueDetailChange,
+  meetingUrl,
+  onMeetingUrlChange,
+  onOrganizerCoordsChange,
   groupActorId,
 }: WhereCardProps) {
+  const isOnline = eventType === "online";
+
+  // Silent GPS capture: only fires when the user is toggling to online AND
+  // the browser has already granted geolocation permission. We never trigger
+  // a fresh permission prompt from this form.
+  useEffect(() => {
+    if (!isOnline) {
+      onOrganizerCoordsChange(null);
+      return;
+    }
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+
+    let cancelled = false;
+
+    const requestCoords = () => {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          if (cancelled) return;
+          onOrganizerCoordsChange({
+            lat: pos.coords.latitude,
+            lng: pos.coords.longitude,
+          });
+        },
+        () => {
+          if (cancelled) return;
+          onOrganizerCoordsChange(null);
+        },
+        { enableHighAccuracy: false, timeout: 3000 },
+      );
+    };
+
+    if (navigator.permissions?.query) {
+      navigator.permissions
+        .query({ name: "geolocation" as PermissionName })
+        .then((status) => {
+          if (cancelled) return;
+          if (status.state === "granted") {
+            requestCoords();
+          }
+        })
+        .catch(() => {});
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOnline, onOrganizerCoordsChange]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Where</CardTitle>
-        <CardDescription>Add a location for your event.</CardDescription>
+        <CardDescription>
+          {isOnline ? "Add a meeting link for your online event." : "Add a location for your event."}
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <PlacePicker
-          value={selectedPlace}
-          onChange={onSelectedPlaceChange}
-          groupActorId={groupActorId}
-        />
-        <div className="space-y-1.5">
-          <Label htmlFor="venueDetail">Venue detail (optional)</Label>
-          <Input
-            id="venueDetail"
-            type="text"
-            placeholder="e.g. 3F, Room 301"
-            value={venueDetail}
-            onChange={(e) => onVenueDetailChange(e.target.value)}
-          />
+        <div
+          role="tablist"
+          aria-label="Event format"
+          className="inline-flex rounded-md border border-border bg-muted p-0.5 text-sm"
+        >
+          {(
+            [
+              { value: "in_person", label: "In-person" },
+              { value: "online", label: "Online" },
+            ] as const
+          ).map((opt) => {
+            const selected = eventType === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                onClick={() => onEventTypeChange(opt.value)}
+                className={cn(
+                  "rounded-md px-3 py-1 transition-colors",
+                  selected
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
         </div>
+
+        {isOnline ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="meetingUrl">Meeting URL *</Label>
+            <Input
+              id="meetingUrl"
+              type="url"
+              placeholder="https://zoom.us/j/... or https://meet.google.com/..."
+              value={meetingUrl}
+              onChange={(e) => onMeetingUrlChange(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Participants will see this link on the event page. Zoom, Google Meet, Discord, etc.
+            </p>
+          </div>
+        ) : (
+          <>
+            <PlacePicker
+              value={selectedPlace}
+              onChange={onSelectedPlaceChange}
+              groupActorId={groupActorId}
+            />
+            <div className="space-y-1.5">
+              <Label htmlFor="venueDetail">Venue detail (optional)</Label>
+              <Input
+                id="venueDetail"
+                type="text"
+                placeholder="e.g. 3F, Room 301"
+                value={venueDetail}
+                onChange={(e) => onVenueDetailChange(e.target.value)}
+              />
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/hooks/useEventDetail.ts
+++ b/src/hooks/useEventDetail.ts
@@ -19,6 +19,8 @@ export type EventData = {
     placeLatitude: string | null;
     placeLongitude: string | null;
     externalUrl: string | null;
+    eventType: "in_person" | "online" | null;
+    meetingUrl: string | null;
     headerImageUrl: string | null;
     groupHandle: string | null;
     groupName: string | null;

--- a/src/routes/events/$eventId/dashboard/edit.tsx
+++ b/src/routes/events/$eventId/dashboard/edit.tsx
@@ -11,7 +11,8 @@ import { renderMarkdown } from "~/lib/markdown";
 import { Label } from "~/components/ui/label";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Checkbox } from "~/components/ui/checkbox";
-import { PlacePicker, type SelectedPlace } from "~/components/PlacePicker";
+import { type SelectedPlace } from "~/components/PlacePicker";
+import { WhereCard } from "~/components/event-form/WhereCard";
 import { TimezonePicker } from "~/components/TimezonePicker";
 import { ImageCropper } from "~/components/ImageCropper";
 import { Switch } from "~/components/ui/switch";
@@ -82,6 +83,9 @@ function EditTab() {
   const [timezone, setTimezone] = useState<string | null>(null);
   const [selectedPlace, setSelectedPlace] = useState<SelectedPlace | null>(null);
   const [venueDetail, setVenueDetail] = useState("");
+  const [eventType, setEventType] = useState<"in_person" | "online">("in_person");
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [organizerCoords, setOrganizerCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [externalUrl, setExternalUrl] = useState("");
   const [questions, setQuestions] = useState<QuestionItem[]>([]);
   const [headerImageUrl, setHeaderImageUrl] = useState<string | null>(null);
@@ -133,6 +137,8 @@ function EditTab() {
         setStartsAt(e.startsAt ? utcToDatetimeLocal(e.startsAt, e.timezone) : "");
         setEndsAt(e.endsAt ? utcToDatetimeLocal(e.endsAt, e.timezone) : "");
         setVenueDetail(e.venueDetail ?? "");
+        setEventType(e.eventType === "online" ? "online" : "in_person");
+        setMeetingUrl(e.meetingUrl ?? "");
         if (e.placeId) {
           setSelectedPlace({
             id: e.placeId,
@@ -204,9 +210,13 @@ function EditTab() {
           startsAt: datetimeLocalToUTC(startsAt, timezone),
           endsAt: endsAt ? datetimeLocalToUTC(endsAt, timezone) : undefined,
           timezone: timezone || undefined,
-          placeId: selectedPlace?.id || undefined,
-          location: selectedPlace?.name || undefined,
-          venueDetail: venueDetail.trim() || undefined,
+          eventType,
+          meetingUrl: eventType === "online" ? meetingUrl.trim() || undefined : null,
+          organizerLat: eventType === "online" ? organizerCoords?.lat : undefined,
+          organizerLng: eventType === "online" ? organizerCoords?.lng : undefined,
+          placeId: eventType === "in_person" ? selectedPlace?.id || null : null,
+          location: eventType === "in_person" ? selectedPlace?.name || undefined : undefined,
+          venueDetail: eventType === "in_person" ? venueDetail.trim() || null : null,
           externalUrl: externalUrl.trim() || undefined,
           groupActorId,
           questions: questions
@@ -257,9 +267,13 @@ function EditTab() {
           startsAt: datetimeLocalToUTC(startsAt, timezone),
           endsAt: endsAt ? datetimeLocalToUTC(endsAt, timezone) : undefined,
           timezone: timezone || undefined,
-          placeId: selectedPlace?.id || undefined,
-          location: selectedPlace?.name || undefined,
-          venueDetail: venueDetail.trim() || undefined,
+          eventType,
+          meetingUrl: eventType === "online" ? meetingUrl.trim() || undefined : null,
+          organizerLat: eventType === "online" ? organizerCoords?.lat : undefined,
+          organizerLng: eventType === "online" ? organizerCoords?.lng : undefined,
+          placeId: eventType === "in_person" ? selectedPlace?.id || null : null,
+          location: eventType === "in_person" ? selectedPlace?.name || undefined : undefined,
+          venueDetail: eventType === "in_person" ? venueDetail.trim() || null : null,
           externalUrl: externalUrl.trim() || undefined,
           allowAnonymousRsvp,
           anonymousContactFields: allowAnonymousRsvp ? anonymousContactFields : undefined,
@@ -816,25 +830,17 @@ function EditTab() {
         </Collapsible>
 
         {/* Location */}
-        <div className="space-y-3">
-          <div className="space-y-1.5">
-            <Label>Location (optional)</Label>
-            <PlacePicker
-              value={selectedPlace}
-              onChange={setSelectedPlace}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="venueDetail">Venue detail (optional)</Label>
-            <Input
-              id="venueDetail"
-              type="text"
-              placeholder="e.g. 3F, Room 301"
-              value={venueDetail}
-              onChange={(e) => setVenueDetail(e.target.value)}
-            />
-          </div>
-        </div>
+        <WhereCard
+          eventType={eventType}
+          onEventTypeChange={setEventType}
+          selectedPlace={selectedPlace}
+          onSelectedPlaceChange={setSelectedPlace}
+          venueDetail={venueDetail}
+          onVenueDetailChange={setVenueDetail}
+          meetingUrl={meetingUrl}
+          onMeetingUrlChange={setMeetingUrl}
+          onOrganizerCoordsChange={setOrganizerCoords}
+        />
 
         {/* External registration URL */}
         <div className="space-y-1.5">

--- a/src/routes/events/$eventId/index.tsx
+++ b/src/routes/events/$eventId/index.tsx
@@ -381,7 +381,30 @@ function EventDetailPage() {
           )}
         </div>
 
-        {(event.location || event.placeName) && (
+        {event.eventType === "online" && event.meetingUrl && (
+          <div className="space-y-2">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 size-5 shrink-0 text-muted-foreground">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="size-5">
+                  <path fillRule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h8.5A2.25 2.25 0 0 1 15 4.25v5.5A2.25 2.25 0 0 1 12.75 12h-8.5A2.25 2.25 0 0 1 2 9.75v-5.5Zm2.5 4.75a.75.75 0 0 0 0 1.5h8a.75.75 0 0 0 0-1.5h-8Zm13.5 0a.75.75 0 0 0-.75.75v1.19l-2 2v-5.88l2 2V5.5a.75.75 0 0 1 1.5 0v9a.75.75 0 0 1-1.5 0v-.31l-2-2v1.06a.75.75 0 0 0 1.5 0V10a.75.75 0 0 0-.75-.75Z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Online event</p>
+                <a
+                  href={event.meetingUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-primary hover:underline break-all"
+                >
+                  {event.meetingUrl}
+                </a>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {event.eventType !== "online" && (event.location || event.placeName) && (
           <div className="space-y-2">
             <div className="flex items-start gap-3">
               <div className="mt-0.5 size-5 shrink-0 text-muted-foreground">

--- a/src/routes/events/create.tsx
+++ b/src/routes/events/create.tsx
@@ -80,8 +80,11 @@ function CreateEventPage() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [categoryId, setCategoryId] = useState("");
+  const [eventType, setEventType] = useState<"in_person" | "online">("in_person");
   const [selectedPlace, setSelectedPlace] = useState<SelectedPlace | null>(null);
   const [venueDetail, setVenueDetail] = useState("");
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [organizerCoords, setOrganizerCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [externalUrl, setExternalUrl] = useState("");
   const [startsAt, setStartsAt] = useState("");
   const [endsAt, setEndsAt] = useState("");
@@ -173,9 +176,13 @@ function CreateEventPage() {
         body: JSON.stringify({
           title,
           description: description || undefined,
-          placeId: selectedPlace?.id || undefined,
-          location: selectedPlace?.name || undefined,
-          venueDetail: venueDetail.trim() || undefined,
+          eventType,
+          meetingUrl: eventType === "online" ? meetingUrl.trim() || undefined : undefined,
+          organizerLat: eventType === "online" ? organizerCoords?.lat : undefined,
+          organizerLng: eventType === "online" ? organizerCoords?.lng : undefined,
+          placeId: eventType === "in_person" ? selectedPlace?.id || undefined : undefined,
+          location: eventType === "in_person" ? selectedPlace?.name || undefined : undefined,
+          venueDetail: eventType === "in_person" ? venueDetail.trim() || undefined : undefined,
           externalUrl: externalUrl || undefined,
           categoryId: categoryId || undefined,
           groupActorId: groupActorId || undefined,
@@ -327,10 +334,15 @@ function CreateEventPage() {
           />
 
           <WhereCard
+            eventType={eventType}
+            onEventTypeChange={setEventType}
             selectedPlace={selectedPlace}
             onSelectedPlaceChange={setSelectedPlace}
             venueDetail={venueDetail}
             onVenueDetailChange={setVenueDetail}
+            meetingUrl={meetingUrl}
+            onMeetingUrlChange={setMeetingUrl}
+            onOrganizerCoordsChange={setOrganizerCoords}
             groupActorId={groupActorId || undefined}
           />
 

--- a/src/server/controllers/events/create.ts
+++ b/src/server/controllers/events/create.ts
@@ -26,6 +26,10 @@ export const POST = async ({ request }: { request: Request }) => {
     externalUrl?: string;
     placeId?: string;
     venueDetail?: string;
+    eventType?: string;
+    meetingUrl?: string;
+    organizerLat?: number;
+    organizerLng?: number;
     organizerHandles?: string[];
     questions?: Array<{
       question: string;
@@ -118,10 +122,50 @@ export const POST = async ({ request }: { request: Request }) => {
     return Response.json({ error: "Invalid endsAt date" }, { status: 400 });
   }
 
+  // Normalize event type; default to in-person for back-compat.
+  const eventType = body.eventType === "online" ? "online" : "in_person";
+  const isOnline = eventType === "online";
+
+  // Online events require a meeting URL.
+  let meetingUrl: string | null = null;
+  if (isOnline) {
+    const raw = body.meetingUrl?.trim();
+    if (!raw) {
+      return Response.json(
+        { error: "meetingUrl is required for online events" },
+        { status: 400 },
+      );
+    }
+    try {
+      new URL(raw);
+    } catch {
+      return Response.json(
+        { error: "meetingUrl must be a valid URL" },
+        { status: 400 },
+      );
+    }
+    meetingUrl = raw;
+  }
+
   try {
-    // Auto-detect country from place coordinates
+    // Country logic:
+    // - in_person → derive from place coords (existing behavior)
+    // - online    → reverse-geocode the organizer's browser coords, if provided.
+    //               Fall back to NULL if no coords (event surfaces in global feeds only).
     let country: string | null = null;
-    if (body.placeId) {
+    let resolvedPlaceId: string | null = null;
+    if (isOnline) {
+      if (
+        typeof body.organizerLat === "number"
+        && typeof body.organizerLng === "number"
+        && Number.isFinite(body.organizerLat)
+        && Number.isFinite(body.organizerLng)
+      ) {
+        const result = await reverseGeocodeCountry(body.organizerLat, body.organizerLng);
+        if (result) country = result.code;
+      }
+    } else if (body.placeId) {
+      resolvedPlaceId = body.placeId;
       const [place] = await db
         .select({ latitude: places.latitude, longitude: places.longitude })
         .from(places)
@@ -147,9 +191,11 @@ export const POST = async ({ request }: { request: Request }) => {
         description: body.description ?? null,
         location: body.location ?? null,
         externalUrl: body.externalUrl ?? "",
-        placeId: body.placeId ?? null,
-        venueDetail: body.venueDetail?.trim() || null,
+        placeId: resolvedPlaceId,
+        venueDetail: isOnline ? null : body.venueDetail?.trim() || null,
         country,
+        eventType,
+        meetingUrl,
         published: body.published ?? (isPersonalEvent ? true : false),
         allowAnonymousRsvp: !!body.allowAnonymousRsvp,
         anonymousContactFields: body.allowAnonymousRsvp

--- a/src/server/controllers/events/detail.ts
+++ b/src/server/controllers/events/detail.ts
@@ -27,6 +27,8 @@ export const GET = async ({ request }: { request: Request }) => {
       externalUrl: events.externalUrl,
       placeId: events.placeId,
       venueDetail: events.venueDetail,
+      eventType: events.eventType,
+      meetingUrl: events.meetingUrl,
       headerImageUrl: events.headerImageUrl,
       published: events.published,
       allowAnonymousRsvp: events.allowAnonymousRsvp,

--- a/src/server/controllers/events/ics.ts
+++ b/src/server/controllers/events/ics.ts
@@ -39,6 +39,8 @@ export const GET = async ({
       placeAddress: places.address,
       groupName: actors.name,
       groupHandle: actors.handle,
+      eventType: events.eventType,
+      meetingUrl: events.meetingUrl,
     })
     .from(events)
     .innerJoin(actors, eq(events.groupActorId, actors.id))

--- a/src/server/controllers/events/personal-ics.ts
+++ b/src/server/controllers/events/personal-ics.ts
@@ -19,6 +19,8 @@ const eventSelect = {
   placeAddress: places.address,
   groupName: actors.name,
   groupHandle: actors.handle,
+  eventType: events.eventType,
+  meetingUrl: events.meetingUrl,
 } as const;
 
 export const GET = async ({

--- a/src/server/controllers/events/update.ts
+++ b/src/server/controllers/events/update.ts
@@ -1,11 +1,12 @@
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "~/server/db/client";
-import { actors, events, eventOrganizers, eventQuestions, eventTiers, groupMembers, rsvpAnswers, rsvps } from "~/server/db/schema";
+import { actors, events, eventOrganizers, eventQuestions, eventTiers, groupMembers, places, rsvpAnswers, rsvps } from "~/server/db/schema";
 import { getSessionUser } from "~/server/auth";
 import { getEventCategories } from "~/server/events/categories";
 import { getAcceptedCount, autoPromoteWaitlist } from "~/server/events/waitlist";
 import { sanitizeContactFields } from "~/server/events/rsvp-helpers";
 import { persistRemoteActor } from "~/server/fediverse/resolve";
+import { reverseGeocodeCountry } from "~/server/geo/reverse-geocode";
 import { optional } from "~/server/controllers/utils";
 
 export const POST = async ({ request }: { request: Request }) => {
@@ -27,6 +28,10 @@ export const POST = async ({ request }: { request: Request }) => {
     externalUrl?: string;
     placeId?: string | null;
     venueDetail?: string | null;
+    eventType?: string;
+    meetingUrl?: string | null;
+    organizerLat?: number;
+    organizerLng?: number;
     headerImageUrl?: string | null;
     allowAnonymousRsvp?: boolean;
     anonymousContactFields?: { email?: string; phone?: string } | null;
@@ -145,6 +150,78 @@ export const POST = async ({ request }: { request: Request }) => {
     return Response.json({ error: "Invalid endsAt date" }, { status: 400 });
   }
 
+  // Normalize eventType if the client sent one. If absent, we don't touch the column.
+  const requestedEventType =
+    body.eventType === "online" || body.eventType === "in_person"
+      ? body.eventType
+      : undefined;
+
+  // When switching to online, require + validate meetingUrl.
+  let meetingUrlUpdate: string | null | undefined;
+  let clearPlaceForOnline = false;
+  if (requestedEventType === "online") {
+    const raw = body.meetingUrl?.trim();
+    if (!raw) {
+      return Response.json(
+        { error: "meetingUrl is required for online events" },
+        { status: 400 },
+      );
+    }
+    try {
+      new URL(raw);
+    } catch {
+      return Response.json(
+        { error: "meetingUrl must be a valid URL" },
+        { status: 400 },
+      );
+    }
+    meetingUrlUpdate = raw;
+    clearPlaceForOnline = true;
+  } else if (requestedEventType === "in_person") {
+    // Switching back to in-person clears any stale meeting URL.
+    meetingUrlUpdate = null;
+  } else if (body.meetingUrl !== undefined) {
+    // Client sent meetingUrl without changing eventType — honor the patch.
+    meetingUrlUpdate = body.meetingUrl?.trim() || null;
+  }
+
+  // Country recomputation:
+  // - online → derive from organizer GPS coords (if provided), else NULL.
+  // - in_person → if placeId is being set/changed, re-derive from place coords.
+  //   This also fixes the pre-existing bug where country went stale on place change.
+  let countryUpdate: string | null | undefined;
+  if (requestedEventType === "online") {
+    let c: string | null = null;
+    if (
+      typeof body.organizerLat === "number"
+      && typeof body.organizerLng === "number"
+      && Number.isFinite(body.organizerLat)
+      && Number.isFinite(body.organizerLng)
+    ) {
+      const result = await reverseGeocodeCountry(body.organizerLat, body.organizerLng);
+      if (result) c = result.code;
+    }
+    countryUpdate = c;
+  } else if (body.placeId !== undefined) {
+    // Recompute for in-person / any place change.
+    let c: string | null = null;
+    if (body.placeId) {
+      const [place] = await db
+        .select({ latitude: places.latitude, longitude: places.longitude })
+        .from(places)
+        .where(eq(places.id, body.placeId))
+        .limit(1);
+      if (place?.latitude && place?.longitude) {
+        const result = await reverseGeocodeCountry(
+          parseFloat(place.latitude),
+          parseFloat(place.longitude),
+        );
+        if (result) c = result.code;
+      }
+    }
+    countryUpdate = c;
+  }
+
   try {
     // Update event fields
     await db
@@ -158,8 +235,15 @@ export const POST = async ({ request }: { request: Request }) => {
         timezone: optional(body.timezone),
         location: optional(body.location, (v) => v?.trim() || null),
         externalUrl: optional(body.externalUrl, (v) => v?.trim() || ""),
-        placeId: optional(body.placeId, (v) => v || null),
-        venueDetail: optional(body.venueDetail, (v) => v?.trim() || null),
+        placeId: clearPlaceForOnline
+          ? null
+          : optional(body.placeId, (v) => v || null),
+        venueDetail: clearPlaceForOnline
+          ? null
+          : optional(body.venueDetail, (v) => v?.trim() || null),
+        ...(requestedEventType !== undefined ? { eventType: requestedEventType } : {}),
+        ...(meetingUrlUpdate !== undefined ? { meetingUrl: meetingUrlUpdate } : {}),
+        ...(countryUpdate !== undefined ? { country: countryUpdate } : {}),
         headerImageUrl: optional(body.headerImageUrl, (v) => v || null),
         allowAnonymousRsvp: optional(body.allowAnonymousRsvp, (v) => !!v),
         anonymousContactFields: optional(body.allowAnonymousRsvp, (v) =>

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -148,6 +148,10 @@ export const events = pgTable("events", {
   placeId: uuid("place_id").references(() => places.id),
   venueDetail: text("venue_detail"),
   country: varchar("country", { length: 2 }), // ISO 3166-1 alpha-2
+  // "in_person" (default) or "online". Plain varchar avoids pg enum migration pain.
+  eventType: varchar("event_type", { length: 16 }).default("in_person").notNull(),
+  // Join URL for online events (Zoom, Meet, Discord invite, etc.). NULL for in-person.
+  meetingUrl: text("meeting_url"),
   headerImageUrl: text("header_image_url"),
   published: boolean("published").default(false).notNull(),
   priority: integer("priority").default(0).notNull(),

--- a/src/server/events/ics.ts
+++ b/src/server/events/ics.ts
@@ -17,6 +17,8 @@ export interface IcsEvent {
   placeAddress: string | null;
   groupName: string | null;
   groupHandle: string | null;
+  eventType?: string | null;
+  meetingUrl?: string | null;
   organizers?: IcsEventOrganizer[];
   status?: "CONFIRMED" | "TENTATIVE";
 }
@@ -40,11 +42,14 @@ export function formatIcsDate(date: Date): string {
 }
 
 export function buildVevent(event: IcsEvent, baseUrl: string): string {
-  const locationParts = [
-    event.location || event.placeName || event.placeAddress || "",
-    event.venueDetail,
-  ].filter(Boolean);
-  const location = locationParts.join(" — ");
+  const isOnline = event.eventType === "online";
+  const locationParts = isOnline
+    ? [event.meetingUrl || ""]
+    : [
+        event.location || event.placeName || event.placeAddress || "",
+        event.venueDetail,
+      ];
+  const location = locationParts.filter(Boolean).join(" — ");
   const lines = [
     "BEGIN:VEVENT",
     `UID:${event.id}@${new URL(baseUrl).hostname}`,


### PR DESCRIPTION
## Summary

Adds first-class online-event support: organizers toggle In-person / Online on the event form, and online events capture a meeting URL (Zoom/Meet/Discord/etc.) instead of a physical venue. For country discoverability, the browser silently supplies the organizer's geolocation (only when permission is already granted — no fresh prompt), the server reverse-geocodes it to an ISO country code via the existing `reverseGeocodeCountry` utility, and only the country code is persisted — raw coords are discarded. A bonus fix: country now recomputes when an in-person event's `placeId` changes (previously went stale).

---
Assisted-By: Claude Code(claude-opus-4-7)