### PR TITLE
Normalize group poll path params

### DIFF
--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -343,10 +343,14 @@ apiRouter.get("/groups/by-handle/:handle", defineEventHandler(async (event) => {
 apiRouter.patch("/groups/:groupId", defineEventHandler(async (event) => {
   const request = toWebRequest(event);
   const groupId = event.context.params?.groupId;
-  if (!groupId) return Response.json({ error: "groupId is required" }, { status: 400 });
+  if (!groupId) {
+    return Response.json({ error: "groupId is required" }, { status: 400 });
+  }
 
   const handle = await resolveGroupHandle(groupId);
-  if (!handle) return Response.json({ error: "Group not found" }, { status: 404 });
+  if (!handle) {
+    return Response.json({ error: "Group not found" }, { status: 404 });
+  }
 
   return updateGroup({
     request: await forwardJson(request, `/api/groups/${groupId}`, "POST", (body) => ({
@@ -634,24 +638,24 @@ apiRouter.get("/events/:eventId/notices/public", defineEventHandler(async (event
 }));
 
 // --- Poll endpoints ---
-apiRouter.post("/groups/:groupActorId/polls", defineEventHandler(async (event) => {
+apiRouter.post("/groups/:groupId/polls", defineEventHandler(async (event) => {
   const request = toWebRequest(event);
-  const groupActorId = event.context.params?.groupActorId;
-  if (!groupActorId) return Response.json({ error: "groupActorId is required" }, { status: 400 });
+  const groupId = event.context.params?.groupId;
+  if (!groupId) return Response.json({ error: "groupId is required" }, { status: 400 });
 
   return createPoll({
-    request: await forwardJson(request, `/api/groups/${groupActorId}/polls`, "POST", (body) => ({
+    request: await forwardJson(request, `/api/groups/${groupId}/polls`, "POST", (body) => ({
       ...(body ?? {}),
-      groupActorId,
+      groupActorId: groupId,
     })),
   });
 }));
 
-apiRouter.get("/groups/:groupActorId/polls", defineEventHandler(async (event) => {
+apiRouter.get("/groups/:groupId/polls", defineEventHandler(async (event) => {
   const request = toWebRequest(event);
-  const groupActorId = event.context.params?.groupActorId;
+  const groupId = event.context.params?.groupId;
   return listPolls({
-    request: forwardGet(request, `/api/groups/${groupActorId}/polls`, { groupActorId }),
+    request: forwardGet(request, `/api/groups/${groupId}/polls`, { groupActorId: groupId }),
   });
 }));
 


### PR DESCRIPTION
## Summary
This PR makes the group poll UI/API route contract consistent by aligning UI and server-router usage to `/api/groups/:groupId/polls` paths, while keeping backend payload key names (`groupActorId`) unchanged where needed by controllers.
It also improves guard readability in the group update route and keeps group avatar update behavior unchanged.

## Why
- Avoid path-parameter mismatch errors between route handlers and frontend callers.
  - Frontend and API proxies now use a single `:groupId` path segment for group-scoped poll endpoints.
- Keep backend compatibility by preserving existing `groupActorId` body/query keys expected by controllers.
  - This prevents accidental regressions in poll create/list logic that still expects actor ID fields.

## Commit History
- c85c257: Align group poll route params

## Test Plan
- [ ] Run `pnpm typecheck` and `pnpm lint` for affected route/controller types.
- [ ] Manually verify PATCH `/api/groups/<groupId>` and POST `/api/groups/<groupId>/avatar` from the edit page in a deployed environment (non-dev origin).
- [ ] Manually verify poll create/list calls hit `/api/groups/<groupId>/polls` and do not 404.

Assisted-By: Codex(gpt-5.4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated parameter naming in group poll creation and listing endpoints for consistency.

* **Refactor**
  * Enhanced error handling code structure in group management endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->